### PR TITLE
feat(aahp): add reviewed PII allowlist and archive badge flows

### DIFF
--- a/.ai/handoff/LOG-ARCHIVE.index.json
+++ b/.ai/handoff/LOG-ARCHIVE.index.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "sha256": "c9ae834d0da14652c521f35978e38080edd3a0c70930c2782dac66ec4de0a50d",
+      "title": "## [2026-02-26] Previous: AAHP v2 Tooling Implementation"
+    }
+  ]
+}

--- a/.ai/handoff/LOG-ARCHIVE.md
+++ b/.ai/handoff/LOG-ARCHIVE.md
@@ -1,0 +1,26 @@
+# AAHP: Archived Agent Journal
+
+> Older entries rotated from LOG.md. Append-only.
+
+---
+
+## [2026-02-26] Previous: AAHP v2 Tooling Implementation
+
+**Agent:** (prior session)
+**Phase:** 3 (Implementer)
+**Branch:** main
+
+### What was done
+
+- Created all 10 template files in `templates/`
+- Created `scripts/aahp-migrate-v2.sh` (v1 to v2 migration)
+- Created `scripts/lint-handoff.sh` (5 validation checks)
+- Created `schema/aahp-manifest.schema.json` (JSON Schema Draft 2020-12)
+- Created `AAHP-v2-PROPOSAL.md` with full v2 specification
+- Set up LICENSE (now CC BY 4.0, originally MIT), .gitignore
+
+### Decisions made
+
+- Bash-only tooling (no Node.js/Python dependency for core scripts)
+- JSON Schema Draft 2020-12 for manifest validation
+- Pre-commit hook pattern for safety linting

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -6,6 +6,23 @@
 
 ---
 
+## [2026-06-26] Codex: LOG archive flow and reusable badge workflows
+
+**Agent:** Codex
+**Phase:** implementation
+**Branch:** codex/issue-21-pii-allowlist
+**Tasks:** AAHP issues #11 and #12
+
+### What was done
+
+- Added `aahp archive` with the canonical default flow: keep the 10 newest `LOG.md` entries and move entry 11+ to `LOG-ARCHIVE.md`.
+- Added `aahp archive --verify` for CI and local checks.
+- Added archive regression tests for rotation, missing rotation, verification, idempotency, and MANIFEST archive indexing.
+- Added stable per-check workflows: AAHP Lint, Manifest, Archive, and PII Allowlist; AAHP Verify remains the umbrella gate.
+- Documented reusable README badge snippets for downstream repos.
+
+---
+
 ## [2026-06-26] Codex: Reviewed, expiring PII allowlist (issue #21)
 
 **Agent:** Codex

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -27,7 +27,7 @@
 - `node bin/aahp.js --help`
 - `bash scripts/aahp-archive.sh . --verify`
 - `bash scripts/lint-handoff.sh .`
-- `bash node_modules/bats/bin/bats tests/archive.bats tests/lint.bats tests/manifest.bats tests/verify.bats` (67 checks; 2 pre-existing manifest skips)
+- `bash node_modules/bats/bin/bats tests/archive.bats tests/lint.bats tests/manifest.bats tests/verify.bats` (68 checks; 2 pre-existing manifest skips)
 - `bash scripts/verify-handoff.sh . --level full`
 - `git diff --check`
 

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -6,6 +6,21 @@
 
 ---
 
+## [2026-06-26] Codex: Fix manifest badge schema for AAHP JSON files
+
+**Agent:** Codex
+**Phase:** fix
+**Branch:** codex/issue-21-pii-allowlist
+**Tasks:** AAHP PR #13 merge blocker
+
+### What was done
+
+- Fixed `schema/aahp-manifest.schema.json` so MANIFEST file entries can include AAHP-owned JSON handoff files.
+- Allowed `pii-allowlist.json` and `LOG-ARCHIVE.index.json` while keeping unknown JSON files rejected.
+- Reproduced the GitHub Actions `AAHP Manifest` validation locally with `ajv-cli` and confirmed `.ai/handoff/MANIFEST.json valid`.
+
+---
+
 ## [2026-06-26] Codex: Gemini review fixes for AAHP PR #13
 
 **Agent:** Codex

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -264,26 +264,3 @@ An allowlist suppresses only the matching PII finding. Secret detection and ever
 ### Decisions made
 
 - Single source of truth: README.md is the v2 specification document
-
----
-
-## [2026-02-26] Previous: AAHP v2 Tooling Implementation
-
-**Agent:** (prior session)
-**Phase:** 3 (Implementer)
-**Branch:** main
-
-### What was done
-
-- Created all 10 template files in `templates/`
-- Created `scripts/aahp-migrate-v2.sh` (v1 to v2 migration)
-- Created `scripts/lint-handoff.sh` (5 validation checks)
-- Created `schema/aahp-manifest.schema.json` (JSON Schema Draft 2020-12)
-- Created `AAHP-v2-PROPOSAL.md` with full v2 specification
-- Set up LICENSE (now CC BY 4.0, originally MIT), .gitignore
-
-### Decisions made
-
-- Bash-only tooling (no Node.js/Python dependency for core scripts)
-- JSON Schema Draft 2020-12 for manifest validation
-- Pre-commit hook pattern for safety linting

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -6,6 +6,27 @@
 
 ---
 
+## [2026-06-26] Codex: Reviewed, expiring PII allowlist (issue #21)
+
+**Agent:** Codex
+**Phase:** implementation
+**Branch:** codex/issue-21-pii-allowlist
+**Task:** T-031
+
+### What was done
+
+- Added `pii-allowlist.json` schema, template, and cross-platform validator.
+- Allowed only exact, non-expired email matches with a reason and accountable owner.
+- Kept the optional allowlist in MANIFEST checksum coverage.
+- Added regression tests for valid, expired, malformed, wildcard, and secret non-suppression cases.
+- Documented rollout owners for the currently blocked consumer repositories.
+
+### Security decision
+
+An allowlist suppresses only the matching PII finding. Secret detection and every other AAHP verify layer remain non-bypassable.
+
+---
+
 ## [2026-06-20] Claude Opus 4.8 (1M context): Canonical handoff gate (aahp verify)
 
 **Agent:** Claude Opus 4.8 (1M context)

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -6,6 +6,33 @@
 
 ---
 
+## [2026-06-26] Codex: Gemini review fixes for AAHP PR #13
+
+**Agent:** Codex
+**Phase:** fix
+**Branch:** codex/issue-21-pii-allowlist
+**Tasks:** AAHP PR #13 review follow-up
+
+### What was done
+
+- Fixed `bin/aahp.js` top-of-file help syntax so the CLI no longer crashes on parse.
+- Registered the `archive` command in CLI dispatch.
+- Hardened the Node CLI wrapper on Windows to prefer Git Bash over the WSL `bash.exe` shim when available.
+- Adjusted LOG archive rendering to preserve clean separators and newest-first archive order.
+- Kept allowlist TSV stdout clean by separating validator stderr from successful parser output.
+
+### Validation
+
+- `node --check bin/aahp.js`
+- `node bin/aahp.js --help`
+- `bash scripts/aahp-archive.sh . --verify`
+- `bash scripts/lint-handoff.sh .`
+- `bash node_modules/bats/bin/bats tests/archive.bats tests/lint.bats tests/manifest.bats tests/verify.bats` (67 checks; 2 pre-existing manifest skips)
+- `bash scripts/verify-handoff.sh . --level full`
+- `git diff --check`
+
+---
+
 ## [2026-06-26] Codex: LOG archive flow and reusable badge workflows
 
 **Agent:** Codex
@@ -17,7 +44,7 @@
 
 - Added `aahp archive` with the canonical default flow: keep the 10 newest `LOG.md` entries and move entry 11+ to `LOG-ARCHIVE.md`.
 - Added `aahp archive --verify` for CI and local checks.
-- Added archive regression tests for rotation, missing rotation, verification, idempotency, and MANIFEST archive indexing.
+- Added archive regression tests for rotation, missing rotation, verification, truncation detection, idempotency, and MANIFEST archive/index coverage.
 - Added stable per-check workflows: AAHP Lint, Manifest, Archive, and PII Allowlist; AAHP Verify remains the umbrella gate.
 - Documented reusable README badge snippets for downstream repos.
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,16 +3,16 @@
   "project": "AAHP",
   "last_session": {
     "agent": "codex",
-    "session_id": "cli-1782468859",
-    "timestamp": "2026-06-26T10:14:19Z",
-    "commit": "3337d32",
+    "session_id": "cli-1782469219",
+    "timestamp": "2026-06-26T10:20:19Z",
+    "commit": "785a42d",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:a57d8a99b5a4d80c9b80792110a1bf0f0d488de18c2abda760420de969f587e7",
-      "updated": "2026-06-26T10:14:05Z",
+      "checksum": "sha256:6b210b6343bb0970700aabf3253f77e64ce7af149b2a0e829ae5efcfebcc8a79",
+      "updated": "2026-06-26T10:20:15Z",
       "lines": 114,
       "summary": "(no summary available)"
     },
@@ -23,8 +23,8 @@
       "summary": "(no summary available)"
     },
     "LOG.md": {
-      "checksum": "sha256:9e381ad20334e24cdde30d8248b5cc0c460de1975671af0f1cde108a79642dc0",
-      "updated": "2026-06-26T10:14:05Z",
+      "checksum": "sha256:58e9138f8efb556886f3f3f4bd2a6793e185536c60755cee2acb865e1d665ef1",
+      "updated": "2026-06-26T10:20:15Z",
       "lines": 274,
       "summary": "(no summary available)"
     },
@@ -59,10 +59,10 @@
       "summary": "{"
     }
   },
-  "quick_context": "Address Gemini review feedback for PR #13: CLI archive dispatch, archive ordering/index integrity, and allowlist TSV stderr isolation.",
+  "quick_context": "Finish Gemini archive review feedback with standardized LOG separators and reverse-chronological multi-run regression coverage.",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4035,
-    "full_read": 9372
+    "manifest_plus_core": 4041,
+    "full_read": 9378
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,17 +2,17 @@
   "aahp_version": "3.0",
   "project": "AAHP",
   "last_session": {
-    "agent": "codex",
-    "session_id": "cli-1782469977",
-    "timestamp": "2026-06-26T10:32:57Z",
-    "commit": "393b31a",
-    "phase": "fix",
+    "agent": "cli-tool",
+    "session_id": "cli-1782470177",
+    "timestamp": "2026-06-26T10:36:17Z",
+    "commit": "817efdd",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:f464e66bc3c681da09ac5d1a9f1abafa9a06bea41b7bbbe5b5f72d6efce73dcf",
-      "updated": "2026-06-26T10:32:53Z",
+      "checksum": "sha256:f257412245f6208ec1502249b2b0745fe97693a16049e800a85671e31b1252a5",
+      "updated": "2026-06-26T10:35:36Z",
       "lines": 114,
       "summary": "(no summary available)"
     },
@@ -23,10 +23,22 @@
       "summary": "(no summary available)"
     },
     "LOG.md": {
-      "checksum": "sha256:7579c9cd7c87eb2454f4902bc45c024a9bcb54274daccdf4701d353c82a9eb81",
-      "updated": "2026-06-26T10:32:53Z",
-      "lines": 289,
+      "checksum": "sha256:08d903cd6ec745a75fbfeb2a611b6c7e0e810848a1e56f22e714d097e9be7279",
+      "updated": "2026-06-26T10:35:16Z",
+      "lines": 266,
       "summary": "(no summary available)"
+    },
+    "LOG-ARCHIVE.md": {
+      "checksum": "sha256:dd4df677e9dfcd7f72620ae5c25a35e0b0c764ca5807dc79f71163bf29d5542b",
+      "updated": "2026-06-26T10:35:16Z",
+      "lines": 26,
+      "summary": "(no summary available)"
+    },
+    "LOG-ARCHIVE.index.json": {
+      "checksum": "sha256:48bf942ed937ca19b019d2c11eef04ff0633c4c51e3229b61f0a9d158c084d93",
+      "updated": "2026-06-26T10:35:16Z",
+      "lines": 9,
+      "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e96e392db8dab2e9719e542dfa2a10c240d0be16ac6721298c460a22985cbdea",
@@ -59,10 +71,10 @@
       "summary": "{"
     }
   },
-  "quick_context": "Fix AAHP Manifest badge schema so AAHP-owned JSON handoff files validate in GitHub Actions.",
+  "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4070,
-    "full_read": 9494
+    "manifest_plus_core": 4109,
+    "full_read": 9574
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,17 +2,17 @@
   "aahp_version": "3.0",
   "project": "AAHP",
   "last_session": {
-    "agent": "cli-tool",
-    "session_id": "cli-1782468097",
-    "timestamp": "2026-06-26T10:01:37Z",
-    "commit": "0aff420",
-    "phase": "implementation",
+    "agent": "codex",
+    "session_id": "cli-1782468859",
+    "timestamp": "2026-06-26T10:14:19Z",
+    "commit": "3337d32",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:63cd2056dfb933c7b961fc385861dd6c9d0a476d08c39718311eb8d37280f6d1",
-      "updated": "2026-06-26T10:01:33Z",
+      "checksum": "sha256:a57d8a99b5a4d80c9b80792110a1bf0f0d488de18c2abda760420de969f587e7",
+      "updated": "2026-06-26T10:14:05Z",
       "lines": 114,
       "summary": "(no summary available)"
     },
@@ -23,9 +23,9 @@
       "summary": "(no summary available)"
     },
     "LOG.md": {
-      "checksum": "sha256:df89e0dfa5f6f8eb3b7b1bb3118903059ad4665c2ba8d3d4cdbf380d16d1f16d",
-      "updated": "2026-06-26T10:01:33Z",
-      "lines": 247,
+      "checksum": "sha256:9e381ad20334e24cdde30d8248b5cc0c460de1975671af0f1cde108a79642dc0",
+      "updated": "2026-06-26T10:14:05Z",
+      "lines": 274,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
@@ -59,10 +59,10 @@
       "summary": "{"
     }
   },
-  "quick_context": "(no summary available) (no summary available) ",
+  "quick_context": "Address Gemini review feedback for PR #13: CLI archive dispatch, archive ordering/index integrity, and allowlist TSV stderr isolation.",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3960,
-    "full_read": 9116
+    "manifest_plus_core": 4035,
+    "full_read": 9372
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,16 +3,16 @@
   "project": "AAHP",
   "last_session": {
     "agent": "codex",
-    "session_id": "cli-1782469219",
-    "timestamp": "2026-06-26T10:20:19Z",
-    "commit": "785a42d",
+    "session_id": "cli-1782469977",
+    "timestamp": "2026-06-26T10:32:57Z",
+    "commit": "393b31a",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:6b210b6343bb0970700aabf3253f77e64ce7af149b2a0e829ae5efcfebcc8a79",
-      "updated": "2026-06-26T10:20:15Z",
+      "checksum": "sha256:f464e66bc3c681da09ac5d1a9f1abafa9a06bea41b7bbbe5b5f72d6efce73dcf",
+      "updated": "2026-06-26T10:32:53Z",
       "lines": 114,
       "summary": "(no summary available)"
     },
@@ -23,9 +23,9 @@
       "summary": "(no summary available)"
     },
     "LOG.md": {
-      "checksum": "sha256:58e9138f8efb556886f3f3f4bd2a6793e185536c60755cee2acb865e1d665ef1",
-      "updated": "2026-06-26T10:20:15Z",
-      "lines": 274,
+      "checksum": "sha256:7579c9cd7c87eb2454f4902bc45c024a9bcb54274daccdf4701d353c82a9eb81",
+      "updated": "2026-06-26T10:32:53Z",
+      "lines": 289,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
@@ -59,10 +59,10 @@
       "summary": "{"
     }
   },
-  "quick_context": "Finish Gemini archive review feedback with standardized LOG separators and reverse-chronological multi-run regression coverage.",
+  "quick_context": "Fix AAHP Manifest badge schema so AAHP-owned JSON handoff files validate in GitHub Actions.",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4041,
-    "full_read": 9378
+    "manifest_plus_core": 4070,
+    "full_read": 9494
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,29 +3,29 @@
   "project": "AAHP",
   "last_session": {
     "agent": "cli-tool",
-    "session_id": "cli-1782467655",
-    "timestamp": "2026-06-26T09:54:15Z",
-    "commit": "9492b9e",
+    "session_id": "cli-1782468097",
+    "timestamp": "2026-06-26T10:01:37Z",
+    "commit": "0aff420",
     "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:3b77c95269c782ae7cf728d5a2b800a04de741e9c12260f75eafcec6b497ea90",
-      "updated": "2026-06-26T09:54:11Z",
-      "lines": 111,
+      "checksum": "sha256:63cd2056dfb933c7b961fc385861dd6c9d0a476d08c39718311eb8d37280f6d1",
+      "updated": "2026-06-26T10:01:33Z",
+      "lines": 114,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:f6a01246d91bd0c8a80d41c20d8fdd8f11252646d1e2753ca33d7757952bf1df",
-      "updated": "2026-06-26T09:54:11Z",
-      "lines": 212,
+      "checksum": "sha256:6655264246f7177e0c0fae16ea158434c751fcb80641b2eaefccbca3e8589c71",
+      "updated": "2026-06-26T10:01:33Z",
+      "lines": 234,
       "summary": "(no summary available)"
     },
     "LOG.md": {
-      "checksum": "sha256:78a4aeafde8def18dbe7a2c3a8f53a493493e187428ffa9450c1c2012ef285e2",
-      "updated": "2026-06-26T09:54:11Z",
-      "lines": 230,
+      "checksum": "sha256:df89e0dfa5f6f8eb3b7b1bb3118903059ad4665c2ba8d3d4cdbf380d16d1f16d",
+      "updated": "2026-06-26T10:01:33Z",
+      "lines": 247,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
@@ -62,7 +62,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3688,
-    "full_read": 8714
+    "manifest_plus_core": 3960,
+    "full_read": 9116
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,30 +2,30 @@
   "aahp_version": "3.0",
   "project": "AAHP",
   "last_session": {
-    "agent": "claude-opus-4-8",
-    "session_id": "cli-1782048643",
-    "timestamp": "2026-06-21T13:30:43Z",
-    "commit": "a0ea68c",
-    "phase": "fix",
+    "agent": "cli-tool",
+    "session_id": "cli-1782467655",
+    "timestamp": "2026-06-26T09:54:15Z",
+    "commit": "9492b9e",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:f6beca21b423ff2923b72d53078fc886cb555bccd96d0b8c48fe18770100d7dc",
-      "updated": "2026-06-21T13:30:42Z",
-      "lines": 110,
+      "checksum": "sha256:3b77c95269c782ae7cf728d5a2b800a04de741e9c12260f75eafcec6b497ea90",
+      "updated": "2026-06-26T09:54:11Z",
+      "lines": 111,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:633e55051efd2c10bea7255734371f42d9cebc7178a9203abe63b66cabc31746",
-      "updated": "2026-04-05T17:29:32Z",
-      "lines": 202,
+      "checksum": "sha256:f6a01246d91bd0c8a80d41c20d8fdd8f11252646d1e2753ca33d7757952bf1df",
+      "updated": "2026-06-26T09:54:11Z",
+      "lines": 212,
       "summary": "(no summary available)"
     },
     "LOG.md": {
-      "checksum": "sha256:5c5c83244b9b482e982b2a1c8c669d8a1053b4dc38e997c75fb1bdad44ef5ef2",
-      "updated": "2026-06-20T12:39:04Z",
-      "lines": 209,
+      "checksum": "sha256:78a4aeafde8def18dbe7a2c3a8f53a493493e187428ffa9450c1c2012ef285e2",
+      "updated": "2026-06-26T09:54:11Z",
+      "lines": 230,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
@@ -51,14 +51,18 @@
       "updated": "2026-04-05T17:29:32Z",
       "lines": 131,
       "summary": "﻿# AAHP: Autonomous Multi-Agent Workflow"
+    },
+    "pii-allowlist.json": {
+      "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
+      "updated": "2026-06-26T09:36:16Z",
+      "lines": 4,
+      "summary": "{"
     }
   },
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3561,
-    "full_read": 8454
+    "manifest_plus_core": 3688,
+    "full_read": 8714
   }
-  ,"next_task_id": "22"
-  ,"tasks": {"T-018":{"title":"Build canonical aahp verify gate (4 layers)","status":"done","priority":"high","depends_on":[],"created":"2026-06-20T00:00:00Z","completed":"2026-06-20T00:00:00Z"},"T-019":{"title":"Wire pre-commit and pre-push hooks plus installer","status":"done","priority":"high","depends_on":["T-018"],"created":"2026-06-20T00:00:00Z","completed":"2026-06-20T00:00:00Z"},"T-020":{"title":"Add aahp-verify CI workflow (level ci, required check)","status":"done","priority":"medium","depends_on":["T-018"],"created":"2026-06-20T00:00:00Z","completed":"2026-06-20T00:00:00Z"},"T-021":{"title":"Write ROLLOUT.md and propagate gate to improvements","status":"done","priority":"medium","depends_on":["T-018"],"created":"2026-06-20T00:00:00Z","completed":"2026-06-20T00:00:00Z"},"T-001":{"title":"Design v3 task dependency graph schema","status":"done","priority":"high","depends_on":[],"created":"2026-02-26T19:34:00Z","completed":"2026-02-26T20:30:00Z"},"T-002":{"title":"Add task IDs to NEXT_ACTIONS.md and DASHBOARD.md","status":"done","priority":"high","depends_on":[],"created":"2026-02-26T19:34:00Z","completed":"2026-02-26T20:30:00Z"},"T-003":{"title":"Add GitHub Actions CI pipeline","status":"done","priority":"medium","depends_on":[],"created":"2026-02-26T19:34:00Z","completed":"2026-02-26T20:45:00Z"},"T-004":{"title":"Create npx-distributable CLI","status":"done","priority":"medium","depends_on":[],"created":"2026-02-26T19:34:00Z","completed":"2026-02-26T20:45:00Z"},"T-005":{"title":"Add automated script tests (bats)","status":"done","priority":"medium","depends_on":[],"created":"2026-02-26T19:34:00Z","completed":"2026-02-26T20:45:00Z"},"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-02-26T20:49:00Z","github_issue":2,"github_repo":"homeofe/AAHP","completed":"2026-04-12T13:54:05.915Z"},"T-007":{"title":"Fix shellcheck warnings in CI","status":"done","priority":"low","depends_on":[],"created":"2026-02-26T20:49:00Z","completed":"2026-02-27T03:16:55.433Z"},"T-008":{"title":"Add bats tests to CI pipeline","status":"done","priority":"low","depends_on":["T-007"],"created":"2026-02-26T20:49:00Z","completed":"2026-02-27T03:59:20.717Z"},"T-009":{"title":"T-008: Add bats tests to CI pipeline","status":"done","priority":"medium","depends_on":[],"created":"2026-02-28T18:15:05.626Z","notes":"Run the 48 bats tests as part of CI.\n\n- Tests exist in `tests/` (manifest.bats, lint.bats, migrate.bats)\n- CI currently runs shellcheck + lint + schema validation\n- Tests need `bats` installed (available via npm: `npx bats`)\n\n**From AAHP NEXT_ACTIONS**","github_issue":4,"github_repo":"homeofe/AAHP","completed":"2026-02-28T18:23:09.084Z"},"T-010":{"title":"T-007: Fix shellcheck warnings in CI","status":"done","priority":"high","depends_on":[],"created":"2026-02-28T18:15:05.629Z","notes":"Ensure all scripts pass shellcheck when CI runs.\n\n- CI workflow runs shellcheck on all 4 scripts\n- Common issues: unquoted variables, unused vars, non-portable constructs\n\n**From AAHP NEXT_ACTIONS**","github_issue":3,"github_repo":"homeofe/AAHP","completed":"2026-02-28T18:34:32.008Z"},"T-012":{"title":"Package published to npm registry","status":"done","priority":"medium","depends_on":[],"created":"2026-03-01T14:04:35.736Z","github_issue":5,"github_repo":"homeofe/AAHP","completed":"2026-04-12T13:54:05.915Z"},"T-013":{"title":"`npx aahp init` works from any directory","status":"done","priority":"medium","depends_on":[],"created":"2026-03-01T14:04:35.737Z","github_issue":6,"github_repo":"homeofe/AAHP","completed":"2026-04-12T13:54:05.914Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-03-02T03:24:38.876Z","github_issue":7,"github_repo":"homeofe/AAHP","completed":"2026-04-12T13:54:05.914Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"cancelled","priority":"medium","depends_on":[],"created":"2026-03-02T03:24:38.876Z","github_issue":8,"github_repo":"homeofe/AAHP","notes":"Moved to aahp-runner — `aahp status` is a CLI command, bin lives in homeofe/aahp-runner."},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"cancelled","priority":"medium","depends_on":[],"created":"2026-03-02T03:24:38.877Z","github_issue":9,"github_repo":"homeofe/AAHP","notes":"Moved to aahp-runner — `aahp archive` is a CLI command, bin lives in homeofe/aahp-runner."},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-03-02T03:24:38.877Z","github_issue":10,"github_repo":"homeofe/AAHP","completed":"2026-04-12T13:54:05.914Z"}}
 }

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -10,13 +10,24 @@
 
 | Status | Count |
 |--------|-------|
-| Done | 10 |
+| Done | 12 |
 | Ready | 4 |
 | Blocked | 1 |
 
 ---
 
 ## Recently Completed
+
+### T-033: Reusable AAHP badge workflows [medium] (issue #12)
+
+- Added stable per-check workflows for AAHP Verify, Lint, Manifest, Archive, and PII Allowlist.
+- Documented badge snippets for downstream repositories.
+
+### T-032: LOG archive integrity [medium] (issue #11)
+
+- Added `aahp archive` with default keep=10 behavior and `--verify`.
+- Added archive tests and MANIFEST coverage for `LOG-ARCHIVE.md`.
+
 
 ### T-031: Reviewed, expiring PII allowlist [high] (ideabase issue #21)
 
@@ -185,6 +196,17 @@ Option B - Local publish:
 ---
 
 ## Recently Completed
+
+### T-033: Reusable AAHP badge workflows [medium] (issue #12)
+
+- Added stable per-check workflows for AAHP Verify, Lint, Manifest, Archive, and PII Allowlist.
+- Documented badge snippets for downstream repositories.
+
+### T-032: LOG archive integrity [medium] (issue #11)
+
+- Added `aahp archive` with default keep=10 behavior and `--verify`.
+- Added archive tests and MANIFEST coverage for `LOG-ARCHIVE.md`.
+
 
 | ID | Item | Date |
 |----|------|------|

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -10,9 +10,19 @@
 
 | Status | Count |
 |--------|-------|
-| Done | 9 |
+| Done | 10 |
 | Ready | 4 |
 | Blocked | 1 |
+
+---
+
+## Recently Completed
+
+### T-031: Reviewed, expiring PII allowlist [high] (ideabase issue #21)
+
+- Added a strict exact-email allowlist with owner, reason, and expiry fields.
+- Integrated it into `aahp lint` and MANIFEST integrity; it cannot suppress secrets.
+- Added schema, template, rollout owners, and regression tests.
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,7 +1,7 @@
 # AAHP: Current State of the Nation
 
 > Last updated: 2026-06-26 by Codex
-> Commit: (pending #21)
+> Commit: (pending #11/#12)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
 > It reflects the *current* reality, not history. History lives in LOG.md.
@@ -21,7 +21,7 @@ running `aahp verify --level ci` as the intended REQUIRED check (committed now;
 GitHub Actions is OFF org-wide for a cost sweep, so it activates when Actions is
 re-enabled). The gate is verify-only: it never regenerates MANIFEST.json, that
 stays a separate /handoff step. Escape hatch `AAHP_SKIP_VERIFY=1` skips local
-verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets.
+verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; reusable per-check badge workflows are now split out for downstream repos.
 <!-- /SECTION: summary -->
 
 ---
@@ -35,6 +35,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | `lint-handoff.sh` | OK | All 6 checks pass |
 | `aahp verify` | OK | New gate: 4 layers, verified end-to-end on a temp repo |
 | `verify.bats` | OK | 12/12 pass |
+| `archive.bats` | OK | 5/5 pass; verifies LOG rotation, postcondition, idempotency, and MANIFEST archive indexing |
 | `lint.bats` | OK | 30 ok, 1 pre-existing skip; adds exact PII allowlist coverage for valid, expired, malformed, wildcard, and secret non-suppression cases |
 | `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present |
 | `cli.bats` | OK | verify help test added; 2 pre-existing Windows-only failures (version-capture flake, read-only-dir) pass on Linux CI |
@@ -96,6 +97,8 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | T-029 | PII check switched to per-match filtering (line-granularity false-negative) | Check 3 extracted whole matched lines and dropped any line containing an excluded token via a line-level `grep -v`, so a genuine external email sharing a single line with an excluded token (a `.noreply.` co-author trailer, `example.com`, or the word `placeholder`) was silently suppressed -a real PII false negative. Switched to per-MATCH filtering: extract each address with `grep -rHnoE` and exclude per ADDRESS in `awk`, so an excluded token elsewhere on the same line can no longer mask a separate real address. Locale-determinism preserved (`grep -E` not `-P`, LC_ALL=C.UTF-8 pin); detection stays byte-identical across locales. 5 new lint.bats T-029 regression tests; bats green; v3.0.5. |
 | T-030 | Add README status-badge block (2026-06-21) | Inserted auto-detected badges after the H1: CI (ci.yml), AAHP Verify (aahp-verify.yml), Security (codeql.yml), npm (@elvatis_com/aahp, published v3.0.5), License Apache-2.0. README change is code outside .ai/handoff, so routed through the drift gate (STATUS.md note + regenerated MANIFEST.json). |
 | T-031 | Reviewed, expiring PII allowlist | Added v3.1.0 allowlist schema/template/validator, exact-match lint support, MANIFEST indexing, rollout owners, and regression tests. |
+| T-032 | LOG archive integrity | Added `aahp archive`, default keep=10 flow, `--verify`, tests, README docs, and LOG-ARCHIVE MANIFEST coverage. |
+| T-033 | Reusable AAHP badge workflows | Added per-check workflows for Verify, Lint, Manifest, Archive, and PII Allowlist plus README badge snippets. |
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -21,7 +21,7 @@ running `aahp verify --level ci` as the intended REQUIRED check (committed now;
 GitHub Actions is OFF org-wide for a cost sweep, so it activates when Actions is
 re-enabled). The gate is verify-only: it never regenerates MANIFEST.json, that
 stays a separate /handoff step. Escape hatch `AAHP_SKIP_VERIFY=1` skips local
-verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; `LOG-ARCHIVE.index.json` records archived-entry hashes so truncation/tampering is detected; reusable per-check badge workflows are now split out for downstream repos. Gemini Code Assist review findings on PR #13 were addressed: the CLI help syntax is fixed, `archive` is registered in command dispatch, archive ordering/separators are stable, and allowlist TSV parsing ignores Python stderr warnings on success.
+verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; `LOG-ARCHIVE.index.json` records archived-entry hashes so truncation/tampering is detected; reusable per-check badge workflows are now split out for downstream repos. Gemini Code Assist review findings on PR #13 were addressed: the CLI help syntax is fixed, `archive` is registered in command dispatch, archive ordering/separators are stable, allowlist TSV parsing ignores Python stderr warnings on success, and the manifest schema now permits AAHP-owned JSON handoff files such as `pii-allowlist.json` and `LOG-ARCHIVE.index.json`.
 <!-- /SECTION: summary -->
 
 ---
@@ -37,7 +37,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | `verify.bats` | OK | 12/12 pass |
 | `archive.bats` | OK | 7/7 pass; verifies LOG rotation, postcondition, truncation detection, idempotency, reverse-chronological separators across repeated rotations, and MANIFEST archive/index coverage |
 | `lint.bats` | OK | 30 ok, 1 pre-existing skip; adds exact PII allowlist coverage for valid, expired, malformed, wildcard, and secret non-suppression cases |
-| `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present |
+| `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present; manifest schema validates the AAHP-owned JSON handoff entries |
 | `cli.bats` | OK | verify help test added; 2 pre-existing Windows-only failures (version-capture flake, read-only-dir) pass on Linux CI |
 | `npx aahp` CLI | OK | init, manifest, lint, migrate, verify, and archive commands registered; source syntax and help verified locally |
 | `shellcheck` | PENDING | Not installable offline on this machine; runs in CI (ci.yml extended to cover the new scripts) |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -21,7 +21,7 @@ running `aahp verify --level ci` as the intended REQUIRED check (committed now;
 GitHub Actions is OFF org-wide for a cost sweep, so it activates when Actions is
 re-enabled). The gate is verify-only: it never regenerates MANIFEST.json, that
 stays a separate /handoff step. Escape hatch `AAHP_SKIP_VERIFY=1` skips local
-verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; `LOG-ARCHIVE.index.json` records archived-entry hashes so truncation/tampering is detected; reusable per-check badge workflows are now split out for downstream repos. Gemini Code Assist review findings on PR #13 were addressed: the CLI help syntax is fixed, `archive` is registered in command dispatch, archive ordering/separators are stable, allowlist TSV parsing ignores Python stderr warnings on success, and the manifest schema now permits AAHP-owned JSON handoff files such as `pii-allowlist.json` and `LOG-ARCHIVE.index.json`.
+verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; `LOG-ARCHIVE.index.json` records archived-entry hashes so truncation/tampering is detected; reusable per-check badge workflows are now split out for downstream repos. Gemini Code Assist review findings on PR #13 were addressed: the CLI help syntax is fixed, `archive` is registered in command dispatch, archive ordering/separators are stable, allowlist TSV parsing ignores Python stderr warnings on success, and the manifest schema now permits AAHP-owned JSON handoff files such as `pii-allowlist.json` and `LOG-ARCHIVE.index.json`. The AAHP Manifest workflow validates committed JSON/schema and verifies the generator on a temp copy instead of diffing volatile session metadata.
 <!-- /SECTION: summary -->
 
 ---
@@ -35,7 +35,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | `lint-handoff.sh` | OK | All 6 checks pass |
 | `aahp verify` | OK | New gate: 4 layers, verified end-to-end on a temp repo |
 | `verify.bats` | OK | 12/12 pass |
-| `archive.bats` | OK | 7/7 pass; verifies LOG rotation, postcondition, truncation detection, idempotency, reverse-chronological separators across repeated rotations, and MANIFEST archive/index coverage |
+| `archive.bats` | OK | 7/7 pass; verifies LOG rotation, postcondition, truncation detection, idempotency, reverse-chronological separators across repeated rotations, and MANIFEST archive/index coverage; repository LOG is currently rotated to 10 active entries |
 | `lint.bats` | OK | 30 ok, 1 pre-existing skip; adds exact PII allowlist coverage for valid, expired, malformed, wildcard, and secret non-suppression cases |
 | `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present; manifest schema validates the AAHP-owned JSON handoff entries |
 | `cli.bats` | OK | verify help test added; 2 pre-existing Windows-only failures (version-capture flake, read-only-dir) pass on Linux CI |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,7 +1,7 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-06-20 by Claude Opus 4.8 (1M context)
-> Commit: (pending)
+> Last updated: 2026-06-26 by Codex
+> Commit: (pending #21)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
 > It reflects the *current* reality, not history. History lives in LOG.md.
@@ -21,7 +21,7 @@ running `aahp verify --level ci` as the intended REQUIRED check (committed now;
 GitHub Actions is OFF org-wide for a cost sweep, so it activates when Actions is
 re-enabled). The gate is verify-only: it never regenerates MANIFEST.json, that
 stays a separate /handoff step. Escape hatch `AAHP_SKIP_VERIFY=1` skips local
-verification only and is ignored at `--level ci`.
+verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets.
 <!-- /SECTION: summary -->
 
 ---
@@ -35,8 +35,8 @@ verification only and is ignored at `--level ci`.
 | `lint-handoff.sh` | OK | All 6 checks pass |
 | `aahp verify` | OK | New gate: 4 layers, verified end-to-end on a temp repo |
 | `verify.bats` | OK | 12/12 pass |
-| `lint.bats` | OK | 26 ok, 1 pre-existing skip (added 5 PII line-granularity tests, T-029) |
-| `manifest.bats` | OK | 18/18 pass |
+| `lint.bats` | OK | 30 ok, 1 pre-existing skip; adds exact PII allowlist coverage for valid, expired, malformed, wildcard, and secret non-suppression cases |
+| `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present |
 | `cli.bats` | OK | verify help test added; 2 pre-existing Windows-only failures (version-capture flake, read-only-dir) pass on Linux CI |
 | `npx aahp` CLI | OK | init, manifest, lint, migrate, verify commands work |
 | `shellcheck` | PENDING | Not installable offline on this machine; runs in CI (ci.yml extended to cover the new scripts) |
@@ -59,8 +59,8 @@ verification only and is ignored at `--level ci`.
 | Verify Tests | `tests/verify.bats` | Complete | 12 tests covering all layers plus escape hatch |
 | Manifest Generator | `scripts/aahp-manifest.sh` | Complete | v3: preserves tasks on regen |
 | Migration Script | `scripts/aahp-migrate-v2.sh` | Complete | Delegates to aahp-manifest.sh |
-| Lint Script | `scripts/lint-handoff.sh` | Complete | 6 checks, cross-platform Python; PII email scan locale-robust (grep -E, T-027) and per-match filtered (grep -rHnoE + awk, T-029) |
-| JSON Schema | `schema/aahp-manifest.schema.json` | Complete | v3: tasks plus next_task_id |
+| Lint Script | `scripts/lint-handoff.sh` | Complete | 6 checks, locale-robust per-match PII scan, reviewed exact/expiring email allowlist, and secret non-suppression |
+| JSON Schemas | `schema/aahp-manifest.schema.json`, `schema/aahp-pii-allowlist.schema.json` | Complete | v3 manifest plus strict reviewed PII allowlist schema |
 | CLI (npx aahp) | `bin/aahp.js` | Complete | verify command registered |
 | CI Pipeline | `.github/workflows/ci.yml` | Complete | shellcheck now covers verify/hooks/installer |
 <!-- /SECTION: components -->
@@ -95,6 +95,7 @@ verification only and is ignored at `--level ci`.
 | T-027 | PII check locale-robust + GitHub noreply exclusion | Check 3 email scan used `grep -rnP` (PCRE); under an empty/non-UTF-8 locale on Windows git-bash GNU grep -P aborts ("supports only unibyte and UTF-8 locales") and the pipeline silently passed (false PASS), while the UTF-8 locale `git commit` sets made it fire -non-deterministic by locale. Switched to `grep -rnE` (POSIX-ERE, no PCRE locale fail-open) with an internal LC_ALL=C.UTF-8 pin, so detection is byte-identical under LC_ALL= (empty), C.UTF-8, and en_US.UTF-8. Added two narrow exclusions (users.noreply.github.com co-author trailers + any *.noreply.* domain); real human/customer emails stay a HARD-FAIL, no allowlist file. 3 new lint.bats tests; bats green; v3.0.4. |
 | T-029 | PII check switched to per-match filtering (line-granularity false-negative) | Check 3 extracted whole matched lines and dropped any line containing an excluded token via a line-level `grep -v`, so a genuine external email sharing a single line with an excluded token (a `.noreply.` co-author trailer, `example.com`, or the word `placeholder`) was silently suppressed -a real PII false negative. Switched to per-MATCH filtering: extract each address with `grep -rHnoE` and exclude per ADDRESS in `awk`, so an excluded token elsewhere on the same line can no longer mask a separate real address. Locale-determinism preserved (`grep -E` not `-P`, LC_ALL=C.UTF-8 pin); detection stays byte-identical across locales. 5 new lint.bats T-029 regression tests; bats green; v3.0.5. |
 | T-030 | Add README status-badge block (2026-06-21) | Inserted auto-detected badges after the H1: CI (ci.yml), AAHP Verify (aahp-verify.yml), Security (codeql.yml), npm (@elvatis_com/aahp, published v3.0.5), License Apache-2.0. README change is code outside .ai/handoff, so routed through the drift gate (STATUS.md note + regenerated MANIFEST.json). |
+| T-031 | Reviewed, expiring PII allowlist | Added v3.1.0 allowlist schema/template/validator, exact-match lint support, MANIFEST indexing, rollout owners, and regression tests. |
 
 ---
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -35,7 +35,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | `lint-handoff.sh` | OK | All 6 checks pass |
 | `aahp verify` | OK | New gate: 4 layers, verified end-to-end on a temp repo |
 | `verify.bats` | OK | 12/12 pass |
-| `archive.bats` | OK | 6/6 pass; verifies LOG rotation, postcondition, truncation detection, idempotency, and MANIFEST archive/index coverage |
+| `archive.bats` | OK | 7/7 pass; verifies LOG rotation, postcondition, truncation detection, idempotency, reverse-chronological separators across repeated rotations, and MANIFEST archive/index coverage |
 | `lint.bats` | OK | 30 ok, 1 pre-existing skip; adds exact PII allowlist coverage for valid, expired, malformed, wildcard, and secret non-suppression cases |
 | `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present |
 | `cli.bats` | OK | verify help test added; 2 pre-existing Windows-only failures (version-capture flake, read-only-dir) pass on Linux CI |
@@ -105,7 +105,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 ## Trust Levels
 
 - **(Verified)**: `aahp verify` runs all 4 layers correctly; drift gate hard-fails, escape hatch skips locally and is ignored at level ci (tested on a temp consumer repo and end-to-end via the installed pre-commit hook).
-- **(Verified)**: selected regression suites pass locally: archive/lint/manifest/verify = 67 checks with 2 pre-existing manifest skips.
+- **(Verified)**: selected regression suites pass locally: archive/lint/manifest/verify = 68 checks with 2 pre-existing manifest skips.
 - **(Verified)**: No em-dashes (U+2014) in any file touched this session.
 - **(Assumed)**: shellcheck clean for the new scripts (syntax-checked with bash -n; full shellcheck runs in CI).
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -21,7 +21,7 @@ running `aahp verify --level ci` as the intended REQUIRED check (committed now;
 GitHub Actions is OFF org-wide for a cost sweep, so it activates when Actions is
 re-enabled). The gate is verify-only: it never regenerates MANIFEST.json, that
 stays a separate /handoff step. Escape hatch `AAHP_SKIP_VERIFY=1` skips local
-verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; reusable per-check badge workflows are now split out for downstream repos.
+verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, exact-value, expiring PII email allowlist that is MANIFEST-indexed and cannot suppress secrets. AAHP v3.2.0 adds the canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and entry 11+ is moved to `LOG-ARCHIVE.md`; `LOG-ARCHIVE.index.json` records archived-entry hashes so truncation/tampering is detected; reusable per-check badge workflows are now split out for downstream repos. Gemini Code Assist review findings on PR #13 were addressed: the CLI help syntax is fixed, `archive` is registered in command dispatch, archive ordering/separators are stable, and allowlist TSV parsing ignores Python stderr warnings on success.
 <!-- /SECTION: summary -->
 
 ---
@@ -35,11 +35,11 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | `lint-handoff.sh` | OK | All 6 checks pass |
 | `aahp verify` | OK | New gate: 4 layers, verified end-to-end on a temp repo |
 | `verify.bats` | OK | 12/12 pass |
-| `archive.bats` | OK | 5/5 pass; verifies LOG rotation, postcondition, idempotency, and MANIFEST archive indexing |
+| `archive.bats` | OK | 6/6 pass; verifies LOG rotation, postcondition, truncation detection, idempotency, and MANIFEST archive/index coverage |
 | `lint.bats` | OK | 30 ok, 1 pre-existing skip; adds exact PII allowlist coverage for valid, expired, malformed, wildcard, and secret non-suppression cases |
 | `manifest.bats` | OK | 19/19 pass; optional `pii-allowlist.json` is indexed when present |
 | `cli.bats` | OK | verify help test added; 2 pre-existing Windows-only failures (version-capture flake, read-only-dir) pass on Linux CI |
-| `npx aahp` CLI | OK | init, manifest, lint, migrate, verify commands work |
+| `npx aahp` CLI | OK | init, manifest, lint, migrate, verify, and archive commands registered; source syntax and help verified locally |
 | `shellcheck` | PENDING | Not installable offline on this machine; runs in CI (ci.yml extended to cover the new scripts) |
 <!-- /SECTION: build_health -->
 
@@ -97,7 +97,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 | T-029 | PII check switched to per-match filtering (line-granularity false-negative) | Check 3 extracted whole matched lines and dropped any line containing an excluded token via a line-level `grep -v`, so a genuine external email sharing a single line with an excluded token (a `.noreply.` co-author trailer, `example.com`, or the word `placeholder`) was silently suppressed -a real PII false negative. Switched to per-MATCH filtering: extract each address with `grep -rHnoE` and exclude per ADDRESS in `awk`, so an excluded token elsewhere on the same line can no longer mask a separate real address. Locale-determinism preserved (`grep -E` not `-P`, LC_ALL=C.UTF-8 pin); detection stays byte-identical across locales. 5 new lint.bats T-029 regression tests; bats green; v3.0.5. |
 | T-030 | Add README status-badge block (2026-06-21) | Inserted auto-detected badges after the H1: CI (ci.yml), AAHP Verify (aahp-verify.yml), Security (codeql.yml), npm (@elvatis_com/aahp, published v3.0.5), License Apache-2.0. README change is code outside .ai/handoff, so routed through the drift gate (STATUS.md note + regenerated MANIFEST.json). |
 | T-031 | Reviewed, expiring PII allowlist | Added v3.1.0 allowlist schema/template/validator, exact-match lint support, MANIFEST indexing, rollout owners, and regression tests. |
-| T-032 | LOG archive integrity | Added `aahp archive`, default keep=10 flow, `--verify`, tests, README docs, and LOG-ARCHIVE MANIFEST coverage. |
+| T-032 | LOG archive integrity | Added `aahp archive`, default keep=10 flow, `--verify`, hash-index truncation detection, tests, README docs, and LOG-ARCHIVE MANIFEST coverage. |
 | T-033 | Reusable AAHP badge workflows | Added per-check workflows for Verify, Lint, Manifest, Archive, and PII Allowlist plus README badge snippets. |
 
 ---
@@ -105,7 +105,7 @@ verification only and is ignored at `--level ci`. AAHP v3.1.0 adds a reviewed, e
 ## Trust Levels
 
 - **(Verified)**: `aahp verify` runs all 4 layers correctly; drift gate hard-fails, escape hatch skips locally and is ignored at level ci (tested on a temp consumer repo and end-to-end via the installed pre-commit hook).
-- **(Verified)**: verify.bats 12/12, lint.bats 26 ok plus 1 pre-existing skip, manifest.bats 18/18 pass locally.
+- **(Verified)**: selected regression suites pass locally: archive/lint/manifest/verify = 67 checks with 2 pre-existing manifest skips.
 - **(Verified)**: No em-dashes (U+2014) in any file touched this session.
 - **(Assumed)**: shellcheck clean for the new scripts (syntax-checked with bash -n; full shellcheck runs in CI).
 

--- a/.ai/handoff/pii-allowlist.json
+++ b/.ai/handoff/pii-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}

--- a/.github/workflows/aahp-archive.yml
+++ b/.github/workflows/aahp-archive.yml
@@ -1,0 +1,21 @@
+name: AAHP Archive
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  aahp-archive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Verify LOG archive flow
+        run: bash scripts/aahp-archive.sh . --verify

--- a/.github/workflows/aahp-lint.yml
+++ b/.github/workflows/aahp-lint.yml
@@ -1,0 +1,21 @@
+name: AAHP Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  aahp-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Run AAHP handoff lint
+        run: bash scripts/lint-handoff.sh .

--- a/.github/workflows/aahp-manifest.yml
+++ b/.github/workflows/aahp-manifest.yml
@@ -1,0 +1,33 @@
+name: AAHP Manifest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  aahp-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Validate MANIFEST JSON
+        run: python -m json.tool .ai/handoff/MANIFEST.json > /dev/null
+      - name: Validate MANIFEST schema
+        run: |
+          npm install --no-save ajv-cli ajv-formats
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
+      - name: Check generated MANIFEST is current
+        run: |
+          bash scripts/aahp-manifest.sh . --quiet --phase implementation
+          git diff --exit-code -- .ai/handoff/MANIFEST.json

--- a/.github/workflows/aahp-manifest.yml
+++ b/.github/workflows/aahp-manifest.yml
@@ -27,7 +27,10 @@ jobs:
         run: |
           npm install --no-save ajv-cli ajv-formats
           npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
-      - name: Check generated MANIFEST is current
+      - name: Check MANIFEST generator
         run: |
-          bash scripts/aahp-manifest.sh . --quiet --phase implementation
-          git diff --exit-code -- .ai/handoff/MANIFEST.json
+          tmpdir="$(mktemp -d)"
+          mkdir -p "$tmpdir/.ai"
+          cp -R .ai/handoff "$tmpdir/.ai/handoff"
+          bash scripts/aahp-manifest.sh "$tmpdir" --quiet --phase implementation
+          python -m json.tool "$tmpdir/.ai/handoff/MANIFEST.json" > /dev/null

--- a/.github/workflows/aahp-pii-allowlist.yml
+++ b/.github/workflows/aahp-pii-allowlist.yml
@@ -1,0 +1,26 @@
+name: AAHP PII Allowlist
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  aahp-pii-allowlist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Validate PII allowlist when present
+        run: |
+          if [ -f .ai/handoff/pii-allowlist.json ]; then
+            python scripts/validate-pii-allowlist.py .ai/handoff/pii-allowlist.json
+          else
+            echo "No PII allowlist configured."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,15 @@ jobs:
           shellcheck -x -P scripts/ scripts/aahp-migrate-v2.sh
           shellcheck scripts/lint-handoff.sh
           shellcheck -x -P scripts/ scripts/verify-handoff.sh
+          shellcheck -x -P scripts/ scripts/aahp-archive.sh
           shellcheck scripts/install-hooks.sh
           shellcheck scripts/hooks/pre-commit
           shellcheck scripts/hooks/pre-push
           shellcheck tests/run.sh
           shellcheck tests/test_helper.bash
+
+      - name: Compile Python validators
+        run: python -m py_compile scripts/validate-pii-allowlist.py
 
       - name: Lint handoff files
         run: bash scripts/lint-handoff.sh .

--- a/README.md
+++ b/README.md
@@ -280,7 +280,23 @@ ghp_*
 
 CI hook validates that no handoff file contains these patterns.
 
-### 2.7 The Verify Gate: `aahp verify`
+### 2.7 Reviewed PII Allowlist
+
+A repository may retain a genuinely necessary operational email only in
+`.ai/handoff/pii-allowlist.json`. The file is optional, but when present it is
+validated during every lint/verify run and is indexed in `MANIFEST.json`.
+
+```json
+{"version":1,"entries":[{"value":"owner@company.example","kind":"email","reason":"Required escalation contact","owner":"Platform Operations","expires":"2026-12-31"}]}
+```
+
+Each entry is an exact email value and must include a reason, owner, and future
+expiry date. Wildcards, domains, regular expressions, duplicate values, and
+expired entries fail verification. An allowed match suppresses only that exact
+PII finding; secrets and all other verification layers still fail normally.
+The canonical schema is `schema/aahp-pii-allowlist.schema.json`.
+
+### 2.8 The Verify Gate: `aahp verify`
 
 Linting and checksums are passive. They tell you when handoff state is malformed,
 but they do not stop an agent from committing code while leaving `STATUS.md` and

--- a/README.md
+++ b/README.md
@@ -349,9 +349,7 @@ aahp archive              # keeps the 10 newest entries
 aahp archive --verify     # fails if LOG.md has more than 10 active entries
 ```
 
-A canonical log entry starts with `## [YYYY-MM-DD]`. The default flow keeps the 10 newest entries in `LOG.md`. Entry 11 and older are moved automatically into `LOG-ARCHIVE.md`, and the postcondition verifies by entry hash that no rotated entry was dropped. `LOG-ARCHIVE.md` is included in
-`MANIFEST.json` whenever present, so archive changes stay inside the checksum
-boundary.
+A canonical log entry starts with `## [YYYY-MM-DD]`. The default flow keeps the 10 newest entries in `LOG.md`. Entry 11 and older are moved automatically into `LOG-ARCHIVE.md`, and the postcondition verifies by entry hash that no rotated entry was dropped. `LOG-ARCHIVE.index.json` stores the hashes of archived entries so `--verify` also detects later truncation or tampering. `LOG-ARCHIVE.md` and the index are included in `MANIFEST.json` whenever present, so archive changes stay inside the checksum boundary.
 
 ## 3. Robustness: Surviving Failures
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/homeofe/AAHP/actions/workflows/ci.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/ci.yml)
 [![AAHP Verify](https://github.com/homeofe/AAHP/actions/workflows/aahp-verify.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/aahp-verify.yml)
+[![AAHP Lint](https://github.com/homeofe/AAHP/actions/workflows/aahp-lint.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/aahp-lint.yml)
+[![AAHP Manifest](https://github.com/homeofe/AAHP/actions/workflows/aahp-manifest.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/aahp-manifest.yml)
+[![AAHP Archive](https://github.com/homeofe/AAHP/actions/workflows/aahp-archive.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/aahp-archive.yml)
+[![AAHP PII Allowlist](https://github.com/homeofe/AAHP/actions/workflows/aahp-pii-allowlist.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/aahp-pii-allowlist.yml)
 [![Security](https://github.com/homeofe/AAHP/actions/workflows/codeql.yml/badge.svg)](https://github.com/homeofe/AAHP/actions/workflows/codeql.yml)
 [![npm](https://img.shields.io/npm/v/@elvatis_com/aahp.svg)](https://www.npmjs.com/package/@elvatis_com/aahp)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
@@ -334,6 +338,20 @@ bypass CI. Never use `git commit/push --no-verify`.
 See `scripts/ROLLOUT.md` for the propagation plan across consumer repos.
 
 ---
+
+### 2.9 LOG Archive Integrity
+
+`LOG.md` is append-only during normal work, but it should stay small enough for
+agents to read quickly. Older entries are rotated into `LOG-ARCHIVE.md` with:
+
+```bash
+aahp archive              # keeps the 10 newest entries
+aahp archive --verify     # fails if LOG.md has more than 10 active entries
+```
+
+A canonical log entry starts with `## [YYYY-MM-DD]`. The default flow keeps the 10 newest entries in `LOG.md`. Entry 11 and older are moved automatically into `LOG-ARCHIVE.md`, and the postcondition verifies by entry hash that no rotated entry was dropped. `LOG-ARCHIVE.md` is included in
+`MANIFEST.json` whenever present, so archive changes stay inside the checksum
+boundary.
 
 ## 3. Robustness: Surviving Failures
 

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -9,14 +9,14 @@
 //   lint [path]       Validate handoff files for safety violations
 //   migrate [path]    Migrate an AAHP v1 project to v2/v3
 //   verify [path]     Run the canonical handoff gate (checksum + drift + TTL)
-  archive [path]    Rotate or verify LOG.md -> LOG-ARCHIVE.md
+//   archive [path]    Rotate or verify LOG.md -> LOG-ARCHIVE.md
 //
 // Options:
 //   --help, -h        Show this help message
 //   --version, -v     Show version number
 
 import { fileURLToPath } from 'node:url'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join, resolve, relative, isAbsolute } from 'node:path'
 import { existsSync, mkdirSync, copyFileSync, readdirSync, readFileSync } from 'node:fs'
 import { spawn } from 'node:child_process'
 
@@ -216,6 +216,37 @@ function cmdInit(targetPath, flags) {
 // We pass the arguments through directly so the scripts see them unchanged.
 // ---------------------------------------------------------------------------
 
+function toBashScriptArg(scriptPath) {
+  if (process.platform !== 'win32') {
+    return scriptPath
+  }
+
+  const relativePath = relative(process.cwd(), scriptPath)
+  if (relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath)) {
+    return relativePath.replace(/\\/g, '/')
+  }
+
+  const drivePath = scriptPath.match(/^([A-Za-z]):\\(.*)$/)
+  if (drivePath) {
+    return `/${drivePath[1].toLowerCase()}/${drivePath[2].replace(/\\/g, '/')}`
+  }
+
+  return scriptPath.replace(/\\/g, '/')
+}
+
+function findBashExecutable() {
+  if (process.platform !== 'win32') {
+    return 'bash'
+  }
+
+  const candidates = [
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) ?? 'bash'
+}
+
 function runScript(scriptName, rest) {
   const scriptPath = join(PACKAGE_ROOT, 'scripts', scriptName)
 
@@ -224,10 +255,12 @@ function runScript(scriptName, rest) {
     process.exit(1)
   }
 
-  // Pass all arguments after the subcommand directly to the bash script
-  const args = [scriptPath, ...rest]
+  // Pass all arguments after the subcommand directly to the bash script.
+  // On Windows, prefer Git Bash over the WSL bash shim and avoid raw C:\... script arguments.
+  const args = [toBashScriptArg(scriptPath), ...rest]
+  const bashExecutable = findBashExecutable()
 
-  const child = spawn('bash', args, {
+  const child = spawn(bashExecutable, args, {
     stdio: 'inherit',
     cwd: process.cwd(),
   })
@@ -235,7 +268,7 @@ function runScript(scriptName, rest) {
   child.on('error', (err) => {
     if (err.code === 'ENOENT') {
       console.error('Error: bash is not available on this system.')
-      console.error('The manifest, lint, and migrate commands require bash.')
+      console.error('The manifest, lint, migrate, verify, and archive commands require bash.')
       console.error('On Windows, install Git for Windows or WSL.')
     } else {
       console.error(`Error spawning script: ${err.message}`)
@@ -295,6 +328,10 @@ switch (command) {
 
   case 'verify':
     runScript('verify-handoff.sh', rest)
+    break
+
+  case 'archive':
+    runScript('aahp-archive.sh', rest)
     break
 
   default:

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -9,6 +9,7 @@
 //   lint [path]       Validate handoff files for safety violations
 //   migrate [path]    Migrate an AAHP v1 project to v2/v3
 //   verify [path]     Run the canonical handoff gate (checksum + drift + TTL)
+  archive [path]    Rotate or verify LOG.md -> LOG-ARCHIVE.md
 //
 // Options:
 //   --help, -h        Show this help message
@@ -47,6 +48,7 @@ Commands:
   lint [path]       Validate handoff files for safety violations
   migrate [path]    Migrate an AAHP v1 project to v2/v3
   verify [path]     Run the canonical handoff gate (checksum + drift + TTL)
+  archive [path]    Rotate or verify LOG.md -> LOG-ARCHIVE.md
 
 Init options:
   --force           Overwrite existing files (default: skip existing)
@@ -74,6 +76,7 @@ Examples:
   npx aahp lint ./my-project
   npx aahp migrate
   npx aahp verify --level ci      # CI gate (no escape hatch)
+  npx aahp archive --verify       # Verify LOG archive integrity
 `)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aahp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aahp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "bin": {
         "aahp": "bin/aahp.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aahp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aahp",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "bin": {
         "aahp": "bin/aahp.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvatis_com/aahp",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "AI-to-AI Handoff Protocol - CLI tools for managing agent handoff files",
   "author": "Elvatis <emre.kohler@elvatis.com>",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvatis_com/aahp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "AI-to-AI Handoff Protocol - CLI tools for managing agent handoff files",
   "author": "Elvatis <emre.kohler@elvatis.com>",
   "bin": {

--- a/schema/aahp-manifest.schema.json
+++ b/schema/aahp-manifest.schema.json
@@ -4,7 +4,13 @@
   "title": "AAHP Manifest",
   "description": "Schema for the AI-to-AI Handoff Protocol MANIFEST.json file (v2/v3)",
   "type": "object",
-  "required": ["aahp_version", "project", "last_session", "files", "quick_context"],
+  "required": [
+    "aahp_version",
+    "project",
+    "last_session",
+    "files",
+    "quick_context"
+  ],
   "properties": {
     "aahp_version": {
       "type": "string",
@@ -18,7 +24,11 @@
     },
     "last_session": {
       "type": "object",
-      "required": ["agent", "timestamp", "phase"],
+      "required": [
+        "agent",
+        "timestamp",
+        "phase"
+      ],
       "properties": {
         "agent": {
           "type": "string",
@@ -39,7 +49,14 @@
         },
         "phase": {
           "type": "string",
-          "enum": ["research", "architecture", "implementation", "review", "fix", "idle"],
+          "enum": [
+            "research",
+            "architecture",
+            "implementation",
+            "review",
+            "fix",
+            "idle"
+          ],
           "description": "Pipeline phase at session end"
         },
         "duration_minutes": {
@@ -53,30 +70,10 @@
       "type": "object",
       "patternProperties": {
         "^.+\\.md$": {
-          "type": "object",
-          "required": ["checksum", "updated", "lines", "summary"],
-          "properties": {
-            "checksum": {
-              "type": "string",
-              "pattern": "^sha256:[a-f0-9]{64}$",
-              "description": "SHA-256 hash of file contents"
-            },
-            "updated": {
-              "type": "string",
-              "format": "date-time",
-              "description": "Last modification timestamp"
-            },
-            "lines": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Line count"
-            },
-            "summary": {
-              "type": "string",
-              "maxLength": 200,
-              "description": "One-line human-readable summary"
-            }
-          }
+          "$ref": "#/$defs/manifestFile"
+        },
+        "^(pii-allowlist|LOG-ARCHIVE\\.index)\\.json$": {
+          "$ref": "#/$defs/manifestFile"
         }
       },
       "additionalProperties": false
@@ -114,7 +111,10 @@
       "patternProperties": {
         "^T-\\d{3,}$": {
           "type": "object",
-          "required": ["title", "status"],
+          "required": [
+            "title",
+            "status"
+          ],
           "properties": {
             "title": {
               "type": "string",
@@ -123,12 +123,23 @@
             },
             "status": {
               "type": "string",
-              "enum": ["ready", "in_progress", "blocked", "done", "cancelled"],
+              "enum": [
+                "ready",
+                "in_progress",
+                "blocked",
+                "done",
+                "cancelled"
+              ],
               "description": "Current task status"
             },
             "priority": {
               "type": "string",
-              "enum": ["critical", "high", "medium", "low"],
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
               "description": "Task priority"
             },
             "depends_on": {
@@ -164,5 +175,38 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "$defs": {
+    "manifestFile": {
+      "type": "object",
+      "required": [
+        "checksum",
+        "updated",
+        "lines",
+        "summary"
+      ],
+      "properties": {
+        "checksum": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "SHA-256 hash of file contents"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modification timestamp"
+        },
+        "lines": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Line count"
+        },
+        "summary": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "One-line human-readable summary"
+        }
+      }
+    }
+  }
 }

--- a/schema/aahp-pii-allowlist.schema.json
+++ b/schema/aahp-pii-allowlist.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/homeofe/AAHP/schema/aahp-pii-allowlist.schema.json",
+  "title": "AAHP PII Allowlist",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "entries"],
+  "properties": {
+    "version": { "const": 1 },
+    "entries": { "type": "array", "items": { "type": "object", "additionalProperties": false, "required": ["value", "kind", "reason", "owner", "expires"], "properties": { "value": { "type": "string", "format": "email" }, "kind": { "const": "email" }, "reason": { "type": "string", "minLength": 1 }, "owner": { "type": "string", "minLength": 1 }, "expires": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" } } } }
+  }
+}

--- a/scripts/ROLLOUT.md
+++ b/scripts/ROLLOUT.md
@@ -60,7 +60,7 @@ is not a bypass: entries are exact, expiring, and MANIFEST-indexed.
 
 Consumer upgrade: propagate the validator, schema, template, and refreshed
 scripts; add reviewed exact entries; run `aahp manifest`; then run
-`aahp verify --level full`. Do not use `AAHP_SKIP_VERIFY` or `--no-verify`.
+`aahp verify --level full`. Do not use `AAHP_SKIP_VERIFY` or `--no-verify`. Run `aahp archive` before `/handoff` whenever `LOG.md` grows past 10 active entries.
 
 ## CI strategy per wave
 

--- a/scripts/ROLLOUT.md
+++ b/scripts/ROLLOUT.md
@@ -46,6 +46,22 @@ first so the repo starts from a clean, in-sync state.
   committed so it activates when Actions is re-enabled. Until then, the local
   hooks are the live enforcement.
 
+## Reviewed PII allowlist rollout
+
+Use `.ai/handoff/pii-allowlist.json` only for reviewed operational context. It
+is not a bypass: entries are exact, expiring, and MANIFEST-indexed.
+
+| Repository | Current blocker | Accountable owner | Required action |
+|---|---|---|---|
+| `atlas` | Scan/report operational addresses | Atlas product team | Redact or approve exact expiring entries, then regenerate MANIFEST. |
+| `elvatis-security-platform` | Shield support/operator addresses | Shield product team | Redact or approve each address individually. |
+| `elvatis-client-portal` | Customer-portal operational addresses | Client Portal team | Redact or approve each address individually. |
+| `elvatis-awareness` | Training/demo operational addresses | Awareness product team | Redact or approve each address individually. |
+
+Consumer upgrade: propagate the validator, schema, template, and refreshed
+scripts; add reviewed exact entries; run `aahp manifest`; then run
+`aahp verify --level full`. Do not use `AAHP_SKIP_VERIFY` or `--no-verify`.
+
 ## CI strategy per wave
 
 - Wave 1 repos: commit the workflow now; once Actions is re-enabled, mark

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -4,7 +4,7 @@
 
 # Standard AAHP handoff files, in canonical order
 # shellcheck disable=SC2034
-AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md LOG-ARCHIVE.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
+AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md LOG-ARCHIVE.md LOG-ARCHIVE.index.json DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
 # Colors (safe to re-source -same variable names used across scripts)
 # shellcheck disable=SC2034

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -4,7 +4,7 @@
 
 # Standard AAHP handoff files, in canonical order
 # shellcheck disable=SC2034
-AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
+AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md LOG-ARCHIVE.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
 # Colors (safe to re-source -same variable names used across scripts)
 # shellcheck disable=SC2034

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -4,7 +4,7 @@
 
 # Standard AAHP handoff files, in canonical order
 # shellcheck disable=SC2034
-AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md)
+AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
 # Colors (safe to re-source -same variable names used across scripts)
 # shellcheck disable=SC2034
@@ -51,6 +51,7 @@ aahp_auto_summary() {
     local filepath="$1"
     local summary
     summary=$(head -5 "$filepath" \
+        | tr -d '\r' \
         | grep -v '^#' | grep -v '^>' | grep -v '^---' | grep -v '^$' \
         | head -1 | cut -c1-150 || true)
     [ -z "$summary" ] && summary="(no summary available)"

--- a/scripts/aahp-archive.sh
+++ b/scripts/aahp-archive.sh
@@ -38,17 +38,20 @@ cd "$PROJECT_ROOT" || { echo "Error: cannot cd into project root: $PROJECT_ROOT"
 HANDOFF_DIR=".ai/handoff"
 LOG="$HANDOFF_DIR/LOG.md"
 ARCHIVE="$HANDOFF_DIR/LOG-ARCHIVE.md"
+INDEX="$HANDOFF_DIR/LOG-ARCHIVE.index.json"
 
-"$PYTHON_CMD" - "$LOG" "$ARCHIVE" "$KEEP" "$VERIFY_ONLY" <<'PY'
+"$PYTHON_CMD" - "$LOG" "$ARCHIVE" "$INDEX" "$KEEP" "$VERIFY_ONLY" <<'PY'
 import hashlib
+import json
 import re
 import sys
 from pathlib import Path
 
 log_path = Path(sys.argv[1])
 archive_path = Path(sys.argv[2])
-keep = int(sys.argv[3])
-verify_only = sys.argv[4].lower() == 'true'
+index_path = Path(sys.argv[3])
+keep = int(sys.argv[4])
+verify_only = sys.argv[5].lower() == 'true'
 entry_re = re.compile(r'^## \[[0-9]{4}-[0-9]{2}-[0-9]{2}\]')
 
 def read(path: Path) -> str:
@@ -63,12 +66,26 @@ def split_doc(text: str):
     entries = []
     for index, start in enumerate(starts):
         end = starts[index + 1] if index + 1 < len(starts) else len(lines)
-        entries.append(''.join(lines[start:end]).rstrip() + '\n')
+        entries.append(''.join(lines[start:end]).rstrip() + '\n\n')
     return preamble, entries
 
 def digest(entry: str) -> str:
     normalized = entry.replace('\r\n', '\n').replace('\r', '\n').strip() + '\n'
     return hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+
+def title(entry: str) -> str:
+    return entry.splitlines()[0].strip() if entry.splitlines() else "(untitled)"
+
+def read_index(path: Path):
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding='utf-8'))
+    if data.get('version') != 1 or not isinstance(data.get('entries'), list):
+        raise SystemExit('LOG-ARCHIVE.index.json is malformed')
+    return data['entries']
+
+def write_index(path: Path, entries):
+    path.write_text(json.dumps({'version': 1, 'entries': entries}, indent=2) + '\n', encoding='utf-8', newline='\n')
 
 if keep < 1:
     raise SystemExit('--keep must be >= 1')
@@ -81,6 +98,13 @@ archive_preamble, archive_entries = split_doc(archive_text)
 archive_hashes = {digest(entry) for entry in archive_entries}
 if len(archive_hashes) != len(archive_entries):
     raise SystemExit('LOG-ARCHIVE.md contains duplicate archived entries')
+index_entries = read_index(index_path)
+indexed_hashes = [entry.get('sha256') for entry in index_entries]
+if len(indexed_hashes) != len(set(indexed_hashes)):
+    raise SystemExit('LOG-ARCHIVE.index.json contains duplicate entries')
+missing_indexed = [h for h in indexed_hashes if h not in archive_hashes]
+if missing_indexed:
+    raise SystemExit('LOG-ARCHIVE.md is missing indexed archived entries')
 if verify_only:
     if len(log_entries) > keep:
         raise SystemExit(f'LOG.md has {len(log_entries)} entries; archive rotation required to keep {keep}')
@@ -97,8 +121,15 @@ missing = [entry for entry in move_entries if digest(entry) not in archive_hashe
 if missing:
     if not archive_preamble.strip():
         archive_preamble = '# AAHP: Archived Agent Journal\n\n> Older entries rotated from LOG.md. Append-only.\n\n---\n\n'
-    archive_body = ''.join(archive_entries + missing)
+    archive_body = ''.join(missing + archive_entries)
     archive_path.write_text(archive_preamble.rstrip() + '\n\n' + archive_body, encoding='utf-8', newline='\n')
+    known = {entry.get('sha256') for entry in index_entries}
+    new_index_entries = []
+    for entry in missing:
+        h = digest(entry)
+        if h not in known:
+            new_index_entries.append({'sha256': h, 'title': title(entry)})
+    write_index(index_path, new_index_entries + index_entries)
 
 log_path.write_text(log_preamble.rstrip() + '\n\n' + ''.join(keep_entries), encoding='utf-8', newline='\n')
 # Verify postcondition.

--- a/scripts/aahp-archive.sh
+++ b/scripts/aahp-archive.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# aahp-archive.sh - Rotate and verify AAHP LOG.md archive integrity.
+#
+# Usage:
+#   aahp-archive.sh [path] [--keep N] [--verify]
+#
+# Default flow: keep the 10 newest LOG.md entries. Entries older than the
+# 10th entry are moved automatically into LOG-ARCHIVE.md.
+#
+# Entry boundary: a log entry starts at a Markdown H2 whose text begins with
+# "[YYYY-MM-DD]", for example: ## [2026-06-26] Agent: Work summary
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aahp-lib.sh
+source "$SCRIPT_DIR/_aahp-lib.sh"
+PYTHON_CMD="$(aahp_python_cmd)"
+[ -n "$PYTHON_CMD" ] || { echo "Error: python is required for archive operations." >&2; exit 1; }
+
+PROJECT_ROOT="."
+KEEP=10
+VERIFY_ONLY=false
+
+if [ $# -gt 0 ] && [[ ! "$1" == --* ]]; then
+    PROJECT_ROOT="$1"
+    shift
+fi
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --keep) KEEP="$2"; shift 2 ;;
+        --verify) VERIFY_ONLY=true; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+cd "$PROJECT_ROOT" || { echo "Error: cannot cd into project root: $PROJECT_ROOT" >&2; exit 1; }
+HANDOFF_DIR=".ai/handoff"
+LOG="$HANDOFF_DIR/LOG.md"
+ARCHIVE="$HANDOFF_DIR/LOG-ARCHIVE.md"
+
+"$PYTHON_CMD" - "$LOG" "$ARCHIVE" "$KEEP" "$VERIFY_ONLY" <<'PY'
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+archive_path = Path(sys.argv[2])
+keep = int(sys.argv[3])
+verify_only = sys.argv[4].lower() == 'true'
+entry_re = re.compile(r'^## \[[0-9]{4}-[0-9]{2}-[0-9]{2}\]')
+
+def read(path: Path) -> str:
+    return path.read_text(encoding='utf-8') if path.exists() else ''
+
+def split_doc(text: str):
+    lines = text.replace('\r\n', '\n').replace('\r', '\n').splitlines(keepends=True)
+    starts = [i for i, line in enumerate(lines) if entry_re.match(line)]
+    if not starts:
+        return ''.join(lines), []
+    preamble = ''.join(lines[:starts[0]])
+    entries = []
+    for index, start in enumerate(starts):
+        end = starts[index + 1] if index + 1 < len(starts) else len(lines)
+        entries.append(''.join(lines[start:end]).rstrip() + '\n')
+    return preamble, entries
+
+def digest(entry: str) -> str:
+    normalized = entry.replace('\r\n', '\n').replace('\r', '\n').strip() + '\n'
+    return hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+
+if keep < 1:
+    raise SystemExit('--keep must be >= 1')
+if not log_path.exists():
+    raise SystemExit(f'{log_path} not found')
+
+log_preamble, log_entries = split_doc(read(log_path))
+archive_text = read(archive_path)
+archive_preamble, archive_entries = split_doc(archive_text)
+archive_hashes = {digest(entry) for entry in archive_entries}
+if len(archive_hashes) != len(archive_entries):
+    raise SystemExit('LOG-ARCHIVE.md contains duplicate archived entries')
+if verify_only:
+    if len(log_entries) > keep:
+        raise SystemExit(f'LOG.md has {len(log_entries)} entries; archive rotation required to keep {keep}')
+    print(f'LOG archive verify passed: LOG.md entries={len(log_entries)}, archived entries={len(archive_entries)}, keep={keep}')
+    raise SystemExit(0)
+
+if len(log_entries) <= keep:
+    print(f'LOG archive up to date: LOG.md entries={len(log_entries)}, keep={keep}')
+    raise SystemExit(0)
+
+keep_entries = log_entries[:keep]
+move_entries = log_entries[keep:]
+missing = [entry for entry in move_entries if digest(entry) not in archive_hashes]
+if missing:
+    if not archive_preamble.strip():
+        archive_preamble = '# AAHP: Archived Agent Journal\n\n> Older entries rotated from LOG.md. Append-only.\n\n---\n\n'
+    archive_body = ''.join(archive_entries + missing)
+    archive_path.write_text(archive_preamble.rstrip() + '\n\n' + archive_body, encoding='utf-8', newline='\n')
+
+log_path.write_text(log_preamble.rstrip() + '\n\n' + ''.join(keep_entries), encoding='utf-8', newline='\n')
+# Verify postcondition.
+_, post_log = split_doc(read(log_path))
+_, post_archive = split_doc(read(archive_path))
+post_hashes = {digest(entry) for entry in post_archive}
+missing_after = [digest(entry) for entry in move_entries if digest(entry) not in post_hashes]
+if len(post_log) > keep or missing_after:
+    raise SystemExit('archive postcondition failed: rotated entries were not fully preserved')
+print(f'LOG archive rotated: kept {len(post_log)} active entries, archived {len(missing)} new older entries')
+PY

--- a/scripts/aahp-archive.sh
+++ b/scripts/aahp-archive.sh
@@ -66,7 +66,10 @@ def split_doc(text: str):
     entries = []
     for index, start in enumerate(starts):
         end = starts[index + 1] if index + 1 < len(starts) else len(lines)
-        entries.append(''.join(lines[start:end]).rstrip() + '\n\n')
+        entry_text = ''.join(lines[start:end]).rstrip()
+        while entry_text.endswith('---'):
+            entry_text = entry_text[:-3].rstrip()
+        entries.append(entry_text)
     return preamble, entries
 
 def digest(entry: str) -> str:
@@ -86,6 +89,9 @@ def read_index(path: Path):
 
 def write_index(path: Path, entries):
     path.write_text(json.dumps({'version': 1, 'entries': entries}, indent=2) + '\n', encoding='utf-8', newline='\n')
+
+def render_entries(entries):
+    return '\n\n---\n\n'.join(entry.strip() for entry in entries if entry.strip())
 
 if keep < 1:
     raise SystemExit('--keep must be >= 1')
@@ -121,8 +127,8 @@ missing = [entry for entry in move_entries if digest(entry) not in archive_hashe
 if missing:
     if not archive_preamble.strip():
         archive_preamble = '# AAHP: Archived Agent Journal\n\n> Older entries rotated from LOG.md. Append-only.\n\n---\n\n'
-    archive_body = ''.join(missing + archive_entries)
-    archive_path.write_text(archive_preamble.rstrip() + '\n\n' + archive_body, encoding='utf-8', newline='\n')
+    archive_body = render_entries(missing + archive_entries)
+    archive_path.write_text(archive_preamble.rstrip() + '\n\n' + archive_body + '\n', encoding='utf-8', newline='\n')
     known = {entry.get('sha256') for entry in index_entries}
     new_index_entries = []
     for entry in missing:
@@ -131,7 +137,8 @@ if missing:
             new_index_entries.append({'sha256': h, 'title': title(entry)})
     write_index(index_path, new_index_entries + index_entries)
 
-log_path.write_text(log_preamble.rstrip() + '\n\n' + ''.join(keep_entries), encoding='utf-8', newline='\n')
+log_body = render_entries(keep_entries)
+log_path.write_text(log_preamble.rstrip() + '\n\n' + log_body + '\n', encoding='utf-8', newline='\n')
 # Verify postcondition.
 _, post_log = split_doc(read(log_path))
 _, post_archive = split_doc(read(archive_path))

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -18,7 +18,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aahp-lib.sh
+source "$SCRIPT_DIR/_aahp-lib.sh"
+
 PROJECT_ROOT="${1:-.}"
+PYTHON_CMD="$(aahp_python_cmd)"
 
 # Path-format-agnostic file access (cross-platform fix).
 # Windows-native Python/Node cannot open an absolute MSYS path like
@@ -119,74 +124,74 @@ else
     VIOLATIONS=$((VIOLATIONS + SECRET_FOUND))
 fi
 
-# ─── Check 3: PII Patterns ───────────────────────────────────
+# --- Check 3: PII Patterns and Reviewed Allowlist ----------------
 
 echo -e "${GREEN}[3/6]${NC} Checking for PII..."
 
-PII_FOUND=0
-# Email check (excluding template/example patterns).
-#
-# Locale-robustness (T-027): the previous implementation used `grep -rnP` (PCRE).
-# On Windows git-bash under an empty or non-UTF-8 locale, GNU grep -P aborts with
-# "grep: -P supports only unibyte and UTF-8 locales" and the pipeline then finds
-# nothing -a silent FALSE PASS. Under the UTF-8 locale that `git commit` sets it
-# works and fires, so the gate was non-deterministic by locale (interactive
-# baseline passed, the commit hook blocked). The pattern is already POSIX-ERE
-# compatible, so we use `grep -E` (ERE has no PCRE locale fail-open) and pin
-# LC_ALL=C.UTF-8 for byte-for-byte identical behaviour on Windows git-bash, the
-# git commit hook, and Linux CI.
-#
-# Exclusions (intentionally narrow -PII stays a HARD-FAIL for genuine external
-# emails):
-#   - example.com / placeholder / *@* template forms
-#   - users.noreply.github.com (GitHub co-author trailers, e.g. Copilot)
-#   - any address whose domain contains ".noreply." (general no-reply form)
-# No real human/customer addresses are whitelisted, and no allowlist file is read.
-#
-# Per-MATCH filtering (T-029): extract each address with grep -o, then exclude per
-# ADDRESS in awk. A line-level grep -v previously dropped the whole matched line, so
-# a genuine external email sharing a line with an excluded token (a noreply trailer,
-# example.com, or the word placeholder) was silently suppressed, a real PII false
-# negative. Filtering each extracted address means an excluded token elsewhere on
-# the same line can no longer mask a separate real address. grep -E (not -P) and the
-# pinned LC_ALL keep detection byte-for-byte identical across locales.
-EMAIL_MATCHES=$(LC_ALL=C.UTF-8 grep -rHnoE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$HANDOFF_DIR"/*.md 2>/dev/null \
-    | awk -F: '
-        {
-            addr = $NF                            # grep -Hno => file:line:address; an address has no colon
-            if (addr ~ /\.noreply\./)       next  # GitHub co-author + any no-reply trailers
-            if (addr ~ /^no-?reply@/)       next  # noreply@ / no-reply@ local-part trailers
-            if (index(addr, "example.com")) next  # template/example domain
-            if (index(addr, "placeholder")) next  # template placeholder address
-            print
-        }' \
-    || true)
-
-if [ -n "$EMAIL_MATCHES" ]; then
-    echo -e "  ${YELLOW}⚠ Possible email addresses found:${NC}"
-    echo "    $EMAIL_MATCHES"
-    PII_FOUND=$((PII_FOUND + 1))
+ALLOWLIST_FILE="$HANDOFF_DIR/pii-allowlist.json"
+ALLOWLIST_ENTRIES=""
+if [ -f "$ALLOWLIST_FILE" ]; then
+    if [ -z "$PYTHON_CMD" ]; then
+        echo -e "  ${RED}x PII allowlist exists but Python is unavailable for validation.${NC}"
+        VIOLATIONS=$((VIOLATIONS + 1))
+    elif ! ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>&1); then
+        echo -e "  ${RED}x $ALLOWLIST_ENTRIES${NC}"
+        ALLOWLIST_ENTRIES=""
+        VIOLATIONS=$((VIOLATIONS + 1))
+    else
+        echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
+    fi
+else
+    echo -e "  ${GREEN}OK No PII allowlist configured.${NC}"
 fi
 
-if [ "$PII_FOUND" -eq 0 ]; then
-    echo -e "  ${GREEN}✓ No PII detected.${NC}"
+if [ -f "$ALLOWLIST_FILE" ] && [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
+    if [ -z "$PYTHON_CMD" ] || ! EXPECTED_CHECKSUM=$("$PYTHON_CMD" - "$HANDOFF_DIR/MANIFEST.json" <<'PY'
+import json, sys
+entry = json.load(open(sys.argv[1], encoding="utf-8")).get("files", {}).get("pii-allowlist.json")
+if not isinstance(entry, dict) or not isinstance(entry.get("checksum"), str):
+    raise SystemExit(1)
+print(entry["checksum"])
+PY
+); then
+        echo -e "  ${RED}x pii-allowlist.json is not indexed by MANIFEST.json. Run /handoff.${NC}"
+        VIOLATIONS=$((VIOLATIONS + 1))
+    elif [ "$EXPECTED_CHECKSUM" != "$(aahp_checksum "$ALLOWLIST_FILE")" ]; then
+        echo -e "  ${RED}x pii-allowlist.json checksum does not match MANIFEST.json. Run /handoff.${NC}"
+        VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+fi
+
+EMAIL_MATCHES=$(LC_ALL=C.UTF-8 grep -rHnoE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$HANDOFF_DIR"/*.md 2>/dev/null | awk -F: '{ addr=$NF; if (addr ~ /\.noreply\./ || addr ~ /^no-?reply@/ || index(addr,"example.com") || index(addr,"placeholder")) next; print }' || true)
+UNAPPROVED=""
+if [ -n "$EMAIL_MATCHES" ]; then
+    while IFS= read -r match; do
+        address="${match##*:}"
+        allowed=0
+        while IFS=$'\t' read -r value owner expires reason; do
+            [ -z "$value" ] && continue
+            if [ "$address" = "$value" ]; then
+                echo -e "  ${GREEN}OK Allowed PII email '$address' via pii-allowlist.json (owner: $owner, expires: $expires).${NC}"
+                allowed=1
+                break
+            fi
+        done <<< "$ALLOWLIST_ENTRIES"
+        [ "$allowed" -eq 1 ] || UNAPPROVED="${UNAPPROVED}${UNAPPROVED:+$'\n'}$match"
+    done <<< "$EMAIL_MATCHES"
+fi
+if [ -n "$UNAPPROVED" ]; then
+    echo -e "  ${YELLOW}Possible email addresses found:${NC}"
+    echo "    $UNAPPROVED"
+    VIOLATIONS=$((VIOLATIONS + 1))
 else
-    VIOLATIONS=$((VIOLATIONS + PII_FOUND))
+    echo -e "  ${GREEN}OK No unapproved PII detected.${NC}"
 fi
 
 # ─── Check 4: MANIFEST.json Basic Validation ─────────────────
 
 echo -e "${GREEN}[4/6]${NC} Validating MANIFEST.json..."
 
-# Detect Python command (python3 on Linux/macOS, python on Windows)
-# Note: Windows has a python3 Store alias that passes `command -v` but doesn't work,
-# so we verify with an actual invocation.
-PYTHON_CMD=""
-if python3 -c "pass" &>/dev/null 2>&1; then
-    PYTHON_CMD="python3"
-elif python -c "pass" &>/dev/null 2>&1; then
-    PYTHON_CMD="python"
-fi
+# Python command was detected before the PII allowlist check.
 
 if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     if [ -z "$PYTHON_CMD" ]; then

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -134,12 +134,20 @@ if [ -f "$ALLOWLIST_FILE" ]; then
     if [ -z "$PYTHON_CMD" ]; then
         echo -e "  ${RED}x PII allowlist exists but Python is unavailable for validation.${NC}"
         VIOLATIONS=$((VIOLATIONS + 1))
-    elif ! ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>&1); then
-        echo -e "  ${RED}x $ALLOWLIST_ENTRIES${NC}"
-        ALLOWLIST_ENTRIES=""
-        VIOLATIONS=$((VIOLATIONS + 1))
     else
-        echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
+        ALLOWLIST_ERR="$(mktemp)"
+        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
+            echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
+        else
+            ALLOWLIST_MESSAGE="$ALLOWLIST_ENTRIES"
+            if [ -s "$ALLOWLIST_ERR" ]; then
+                ALLOWLIST_MESSAGE="${ALLOWLIST_MESSAGE}${ALLOWLIST_MESSAGE:+$'\n'}$(cat "$ALLOWLIST_ERR")"
+            fi
+            echo -e "  ${RED}x $ALLOWLIST_MESSAGE${NC}"
+            ALLOWLIST_ENTRIES=""
+            VIOLATIONS=$((VIOLATIONS + 1))
+        fi
+        rm -f "$ALLOWLIST_ERR"
     fi
 else
     echo -e "  ${GREEN}OK No PII allowlist configured.${NC}"

--- a/scripts/validate-pii-allowlist.py
+++ b/scripts/validate-pii-allowlist.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate AAHP's reviewed, exact, expiring PII email allowlist."""
+from __future__ import annotations
+import argparse, datetime as dt, json, re, sys
+from pathlib import Path
+
+EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\Z")
+ROOT_KEYS = {"version", "entries"}
+ENTRY_KEYS = {"value", "kind", "reason", "owner", "expires"}
+
+def fail(message: str) -> None:
+    print(f"PII allowlist invalid: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+def text(entry, key, index):
+    value = entry.get(key)
+    if not isinstance(value, str) or not value.strip() or any(c in value for c in "\r\n\t"):
+        fail(f"entry {index}: '{key}' must be a non-empty single-line string")
+    return value
+
+def entries(path: Path, today: dt.date):
+    try:
+        document = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON ({exc.msg})")
+    if not isinstance(document, dict) or set(document) != ROOT_KEYS or document.get('version') != 1:
+        fail("root must contain exactly 'version': 1 and 'entries'")
+    raw = document.get('entries')
+    if not isinstance(raw, list):
+        fail("'entries' must be an array")
+    seen, result = set(), []
+    for index, entry in enumerate(raw, 1):
+        if not isinstance(entry, dict) or set(entry) != ENTRY_KEYS:
+            fail(f"entry {index} must contain exactly value, kind, reason, owner, and expires")
+        value, kind = text(entry, 'value', index), text(entry, 'kind', index)
+        reason, owner, expires = text(entry, 'reason', index), text(entry, 'owner', index), text(entry, 'expires', index)
+        if kind != 'email': fail(f"entry {index}: 'kind' must be 'email'")
+        if not EMAIL.fullmatch(value): fail(f"entry {index}: 'value' must be one exact email address; wildcards and regex are forbidden")
+        if value in seen: fail(f"entry {index}: duplicate value '{value}'")
+        seen.add(value)
+        try: expiry = dt.date.fromisoformat(expires)
+        except ValueError: fail(f"entry {index}: 'expires' must be YYYY-MM-DD")
+        if expiry < today: fail(f"entry {index}: allowlist entry for '{value}' expired on {expires}")
+        result.append((value, owner, expires, reason))
+    return result
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('path', type=Path)
+    parser.add_argument('--format', choices=('human','tsv'), default='human')
+    parser.add_argument('--today')
+    args = parser.parse_args()
+    try: today = dt.date.fromisoformat(args.today) if args.today else dt.datetime.now(dt.timezone.utc).date()
+    except ValueError: fail('--today must be YYYY-MM-DD')
+    result = entries(args.path, today)
+    if args.format == 'tsv':
+        for row in result: print('\t'.join(row))
+    else: print(f"PII allowlist valid: {len(result)} active exact email entries.")
+if __name__ == '__main__': main()

--- a/templates/pii-allowlist.json
+++ b/templates/pii-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}

--- a/tests/archive.bats
+++ b/tests/archive.bats
@@ -80,6 +80,56 @@ EOF
     [[ "$output" == *"missing indexed archived entries"* ]]
 }
 
+
+@test "archive preserves reverse chronological order and separators across runs" {
+    _write_log_entries
+    bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    cat > "$TEST_TMPDIR/.ai/handoff/LOG.md" <<'EOF'
+# AAHP: Agent Journal
+
+> Append-only. Never delete or edit past entries.
+
+---
+
+## [2026-06-28] Agent: newest-second-run
+
+newest second body
+
+---
+
+## [2026-06-27] Agent: moved-second-run
+
+moved second body
+
+---
+
+## [2026-06-26] Agent: newest
+
+newest body without trailing separator
+EOF
+    bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    source "$SCRIPTS_DIR/_aahp-lib.sh"
+    PYTHON_CMD="$(aahp_python_cmd)"
+    "$PYTHON_CMD" - "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md" <<'PY'
+from pathlib import Path
+import sys
+text = Path(sys.argv[1]).read_text(encoding='utf-8')
+expected = [
+    '## [2026-06-27] Agent: moved-second-run',
+    '## [2026-06-26] Agent: newest',
+    '## [2026-06-25] Agent: middle',
+    '## [2026-06-24] Agent: oldest',
+]
+positions = [text.index(item) for item in expected]
+if positions != sorted(positions):
+    raise SystemExit(f'archive order is not reverse chronological: {positions}')
+for left, right in zip(expected, expected[1:]):
+    chunk = text[text.index(left):text.index(right)]
+    if '\n---\n\n' not in chunk:
+        raise SystemExit(f'missing separator between {left} and {right}')
+PY
+}
+
 @test "manifest indexes LOG-ARCHIVE.md when present" {
     create_status_md
     create_next_actions_md

--- a/tests/archive.bats
+++ b/tests/archive.bats
@@ -71,12 +71,23 @@ EOF
     [ "$before" = "$after" ]
 }
 
+@test "archive verify fails when LOG-ARCHIVE.md is truncated" {
+    _write_log_entries
+    bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    echo "# truncated" > "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md"
+    run bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1 --verify
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing indexed archived entries"* ]]
+}
+
 @test "manifest indexes LOG-ARCHIVE.md when present" {
     create_status_md
     create_next_actions_md
     create_log_md
     echo "# Archive" > "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md"
+    echo '{"version":1,"entries":[]}' > "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.index.json"
     run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
     [ "$status" -eq 0 ]
     grep -q '"LOG-ARCHIVE.md"' "$TEST_TMPDIR/.ai/handoff/MANIFEST.json"
+    grep -q '"LOG-ARCHIVE.index.json"' "$TEST_TMPDIR/.ai/handoff/MANIFEST.json"
 }

--- a/tests/archive.bats
+++ b/tests/archive.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# archive.bats - Tests for scripts/aahp-archive.sh
+
+setup() {
+    load test_helper
+    setup
+    mkdir -p "$TEST_TMPDIR/.ai/handoff"
+}
+
+teardown() {
+    teardown
+}
+
+_write_log_entries() {
+    cat > "$TEST_TMPDIR/.ai/handoff/LOG.md" <<'EOF'
+# AAHP: Agent Journal
+
+> Append-only. Never delete or edit past entries.
+
+---
+
+## [2026-06-26] Agent: newest
+
+newest body
+
+---
+
+## [2026-06-25] Agent: middle
+
+middle body
+
+---
+
+## [2026-06-24] Agent: oldest
+
+oldest body
+EOF
+}
+
+@test "archive rotates older entries into LOG-ARCHIVE.md" {
+    _write_log_entries
+    run bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    [ "$status" -eq 0 ]
+    grep -q "newest" "$TEST_TMPDIR/.ai/handoff/LOG.md"
+    ! grep -q "middle" "$TEST_TMPDIR/.ai/handoff/LOG.md"
+    grep -q "middle" "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md"
+    grep -q "oldest" "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md"
+}
+
+@test "archive verify fails when rotation is still required" {
+    _write_log_entries
+    run bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1 --verify
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"archive rotation required"* ]]
+}
+
+@test "archive verify passes after rotation" {
+    _write_log_entries
+    bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    run bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1 --verify
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"LOG archive verify passed"* ]]
+}
+
+@test "archive rotation is idempotent" {
+    _write_log_entries
+    bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    before=$(sha256sum "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md" | awk '{print $1}')
+    bash "$SCRIPTS_DIR/aahp-archive.sh" "$TEST_TMPDIR" --keep 1
+    after=$(sha256sum "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md" | awk '{print $1}')
+    [ "$before" = "$after" ]
+}
+
+@test "manifest indexes LOG-ARCHIVE.md when present" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    echo "# Archive" > "$TEST_TMPDIR/.ai/handoff/LOG-ARCHIVE.md"
+    run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+    grep -q '"LOG-ARCHIVE.md"' "$TEST_TMPDIR/.ai/handoff/MANIFEST.json"
+}

--- a/tests/lint.bats
+++ b/tests/lint.bats
@@ -157,7 +157,7 @@ teardown() {
 
     run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"No PII detected"* ]]
+    [[ "$output" == *"No unapproved PII detected"* ]]
     [[ "$output" != *"123456+Copilot@users.noreply.github.com"* ]]
 }
 
@@ -212,10 +212,65 @@ teardown() {
 
     run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"No PII detected"* ]]
+    [[ "$output" == *"No unapproved PII detected"* ]]
 }
 
-# ─── Invalid JSON in MANIFEST.json ───────────────────────────
+# ??? Reviewed PII allowlist (issue #21) ??????????????????????
+
+@test "allows one exact non-expired email and reports its matching entry" {
+    create_full_handoff
+    cat > "$TEST_TMPDIR/.ai/handoff/pii-allowlist.json" <<'JSON'
+{"version":1,"entries":[{"value":"owner@company.test","kind":"email","reason":"Required operational owner reference","owner":"Platform Operations","expires":"2099-01-01"}]}
+JSON
+    bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    echo "Contact owner@company.test for escalation." >> "$TEST_TMPDIR/.ai/handoff/STATUS.md"
+    run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Allowed PII email 'owner@company.test'"* ]]
+}
+
+@test "rejects an expired PII allowlist entry" {
+    create_full_handoff
+    cat > "$TEST_TMPDIR/.ai/handoff/pii-allowlist.json" <<'JSON'
+{"version":1,"entries":[{"value":"owner@company.test","kind":"email","reason":"Required operational owner reference","owner":"Platform Operations","expires":"2000-01-01"}]}
+JSON
+    run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"expired on 2000-01-01"* ]]
+}
+
+@test "rejects malformed and wildcard PII allowlist entries" {
+    create_full_handoff
+    cat > "$TEST_TMPDIR/.ai/handoff/pii-allowlist.json" <<'JSON'
+{"version":1,"entries":[{"value":"*@company.test","kind":"email","reason":"Wildcard should never be accepted","owner":"Platform Operations","expires":"2099-01-01"}]}
+JSON
+    run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"one exact email address"* ]]
+    cat > "$TEST_TMPDIR/.ai/handoff/pii-allowlist.json" <<'JSON'
+{"version":1,"entries":[{"value":"owner@company.test","kind":"email","reason":"Missing owner","expires":"2099-01-01"}]}
+JSON
+    run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must contain exactly value, kind, reason, owner, and expires"* ]]
+}
+
+@test "PII allowlist never suppresses secret detection" {
+    create_full_handoff
+    cat > "$TEST_TMPDIR/.ai/handoff/pii-allowlist.json" <<'JSON'
+{"version":1,"entries":[{"value":"owner@company.test","kind":"email","reason":"Required operational owner reference","owner":"Platform Operations","expires":"2099-01-01"}]}
+JSON
+    bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    echo "Contact owner@company.test. API_KEY=sk-abcdef1234567890abcdef" >> "$TEST_TMPDIR/.ai/handoff/STATUS.md"
+    run bash "$SCRIPTS_DIR/lint-handoff.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"secret pattern"* ]]
+    [[ "$output" == *"Allowed PII email 'owner@company.test'"* ]]
+}
+
+# ??? Invalid JSON in MANIFEST.json ???????????????????????????
 
 @test "detects invalid JSON in MANIFEST.json" {
     create_full_handoff

--- a/tests/manifest.bats
+++ b/tests/manifest.bats
@@ -82,7 +82,17 @@ _detect_python() {
     [[ "$manifest_content" == *'"full_read"'* ]]
 }
 
-# ─── CLI flag: --agent ───────────────────────────────────────
+@test "indexes an optional pii allowlist in MANIFEST.json" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    echo '{"version":1,"entries":[]}' > "$TEST_TMPDIR/.ai/handoff/pii-allowlist.json"
+    run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+    grep -q '"pii-allowlist.json"' "$TEST_TMPDIR/.ai/handoff/MANIFEST.json"
+}
+
+# ??? CLI flag: --agent ???????????????????????????????????????
 
 @test "--agent flag sets agent name in output" {
     create_status_md

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,7 +26,7 @@ if [ $# -gt 0 ]; then
     # Run a specific test suite
     suite="$1"
     case "$suite" in
-        manifest|lint|migrate)
+        manifest|lint|migrate|archive)
             echo "Running $suite tests..."
             $BATS "$SCRIPT_DIR/${suite}.bats"
             ;;


### PR DESCRIPTION
﻿## Summary

Implements the AAHP upstream work for:

- ideabase issue #21: reviewed, exact, expiring PII email allowlists for `aahp lint` / `aahp verify`
- AAHP issue #11: canonical LOG archive flow (`LOG.md` keeps 10 newest entries; entry 11+ moves to `LOG-ARCHIVE.md`)
- AAHP issue #12: reusable per-check badge workflows

## Changes

- Adds `.ai/handoff/pii-allowlist.json`, schema, template, and cross-platform validator.
- Keeps PII allowlists inside MANIFEST checksum coverage.
- Suppresses only exact, non-expired allowed email findings; secrets remain non-suppressible.
- Adds `aahp archive` and `aahp archive --verify`.
- Stores archived-entry hashes in `LOG-ARCHIVE.index.json`, so `--verify` detects truncated/tampered archives.
- Preserves reverse-chronological archive order across repeated rotations and writes standard `---` separators between entries.
- Adds stable workflows: `AAHP Lint`, `AAHP Manifest`, `AAHP Archive`, `AAHP PII Allowlist`; `AAHP Verify` remains the umbrella gate.
- Documents reusable badge snippets for downstream repos.
- Addresses Gemini Code Assist review feedback: fixed CLI help syntax, registered `archive` dispatch, separated allowlist validator stderr from TSV stdout, and added archive ordering/separator regression coverage.

## Validation

- Workflow YAML parsed successfully for all `aahp-*.yml` workflows and `ci.yml`.
- `node --check bin/aahp.js`
- `node bin/aahp.js --help`
- `bash scripts/aahp-archive.sh . --verify`
- `bash scripts/lint-handoff.sh .`
- `bash node_modules/bats/bin/bats tests/archive.bats tests/lint.bats tests/manifest.bats tests/verify.bats` -> 68 checks, 2 existing environment skips in manifest preservation tests.
- `bash scripts/verify-handoff.sh . --level full` -> pass; one pre-existing advisory TRUST-TTL warning remains.
- `git diff --check`

## Local note

`AGENTS.md` remains untracked locally and is not part of this PR.
