### PR TITLE
chore(handoff): refresh manifest commit-pointer to clear CI Layer 3

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,85 +3,85 @@
   "project": "AAHP",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1783959676",
-    "timestamp": "2026-07-13T16:21:16Z",
-    "commit": "2c21282",
-    "phase": "fix",
+    "session_id": "cli-1784008044",
+    "timestamp": "2026-07-14T05:47:25Z",
+    "commit": "f040bfb",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:fb85f3201dab827436c34441dc82352ec1d7068152f5ce77117b19178f6b263e",
-      "updated": "2026-07-13T16:21:06Z",
-      "lines": 127,
+      "checksum": "sha256:d598f2c2310f5ab7ccf7b3eaade03ffc89e29e5ee75731ccec9fdf4b354d622d",
+      "updated": "2026-07-14T05:47:17Z",
+      "lines": 132,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:50de9129b820e50f0a23859fa482b88390196c0c8653bdd235e8c45839a42715",
-      "updated": "2026-06-28T10:10:28Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 234,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:08d903cd6ec745a75fbfeb2a611b6c7e0e810848a1e56f22e714d097e9be7279",
-      "updated": "2026-06-26T10:38:49Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 266,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:dd4df677e9dfcd7f72620ae5c25a35e0b0c764ca5807dc79f71163bf29d5542b",
-      "updated": "2026-06-26T10:38:49Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 26,
       "summary": "(no summary available)"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:48bf942ed937ca19b019d2c11eef04ff0633c4c51e3229b61f0a9d158c084d93",
-      "updated": "2026-06-26T10:38:49Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 9,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e96e392db8dab2e9719e542dfa2a10c240d0be16ac6721298c460a22985cbdea",
-      "updated": "2026-04-05T17:29:32Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 96,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:525c39c153a6f2f34f3ad1d64bbe2915b3548b93f3228579bb6a804437b375a7",
-      "updated": "2026-07-13T16:17:55Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 91,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:aa576e7c37de31ea6e2b5e4cc3e15ba4494571798a0e42f276f505ba9cac24af",
-      "updated": "2026-04-05T17:29:32Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 114,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:62ac58c749c907cf2eb9236172cd11d3a81128a855e8946e93e436ee016745be",
-      "updated": "2026-06-28T06:56:53Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-07-13T16:17:31Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 209,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-26T10:38:49Z",
+      "updated": "2026-07-14T05:45:01Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "PR #25 review fixes: migration guard, hard-fail on missing template, provenance-column note, band/phase clarifications.",
+  "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4545,
-    "full_read": 12118
+    "manifest_plus_core": 4612,
+    "full_read": 12185
   }
   ,"next_task_id": 6
   ,"tasks": {"T-001":{"title":"[T-006] Publish npm package","status":"blocked","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP"},"T-002":{"title":"[T-014] Add CLI integration tests for bin/aahp.js [high]","status":"ready","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"ready","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,7 +1,12 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-07-13 by claude-opus-4-8 (branch feat/grounded-reflection-layer)
+> Last updated: 2026-07-14 by claude-opus-4-8 (branch chore/refresh-handoff-pointer-layer3)
 > Commit: (pending)
+>
+> Note (2026-07-14): Manifest commit-pointer refreshed against the main base
+> commit to clear a CI Layer 3 stale-pointer failure. PR #25 was squash-merged,
+> which orphaned the recorded branch commit (2c21282) so it was no longer an
+> ancestor of HEAD. No source code changed; this is a handoff-only refresh.
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
 > It reflects the *current* reality, not history. History lives in LOG.md.


### PR DESCRIPTION
## What

Regenerates `.ai/handoff/MANIFEST.json` so `last_session.commit` points at the current main base commit (`f040bfb`), and adds an audit note to `STATUS.md`. Handoff-only change; no source code touched.

## Why

`AAHP Verify` is red on `main` at Layer 3 (commit-pointer freshness):

```
FAIL: MANIFEST commit (2c21282) is not an ancestor of HEAD (f040bfb). Stale manifest.
```

PR #25 was squash-merged. The squash collapsed the branch into a new main commit and orphaned the branch commit `2c21282` that `MANIFEST.last_session.commit` recorded, so it was no longer an ancestor of HEAD. Layers 1 (checksums) and 2 (content-drift) still pass; only the pointer-liveness check trips. This is the same break that PR #21 hand-fixed once before.

## Fix

The manifest was regenerated while HEAD was still the base commit, so the pointer now lands on a commit that survives the merge. After this lands, Layer 3 reports WARN (pointer behind HEAD), which passes.

## Verification (local, Windows git)

- `bash scripts/verify-handoff.sh . --level ci` -> `aahp verify passed (level: ci)`; Layer 3 is WARN, not FAIL.
- `bash scripts/lint-handoff.sh .` -> 0 checksum mismatches (checksums are CR-stripped, so CRLF vs LF is irrelevant).

## Merge note

Please **merge via a merge commit, not squash or rebase**. A merge commit keeps this branch commit as an ancestor of main, so the refreshed pointer stays valid. A squash would orphan it again and re-trip Layer 3, exactly the loop this PR is clearing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>