### PR TITLE
feat(release): documentation phase + cross_repo_ref preservation (v3.5.0)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "AAHP-spec",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1784021089",
-    "timestamp": "2026-07-14T09:24:49Z",
-    "commit": "30b4677",
-    "phase": "implementation",
+    "session_id": "cli-1784022441",
+    "timestamp": "2026-07-14T09:47:21Z",
+    "commit": "f1a9bcf",
+    "phase": "documentation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:0164abb3d599d2abc4810df7b5f0095754c921a1bc2b3cd1bdddbaa8dd002712",
-      "updated": "2026-07-14T09:24:00Z",
-      "lines": 135,
+      "checksum": "sha256:4ae48b184d61de9aad722b6f9114e37b591ec570b6755fce52c6b77336128fa7",
+      "updated": "2026-07-14T09:47:20Z",
+      "lines": 137,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Added Sections 9+10, completed CLI docs and Grounding inline spec. v3.4.0",
+  "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4723,
-    "full_read": 12296
+    "manifest_plus_core": 4841,
+    "full_read": 12414
   }
   ,"next_task_id": 6
   ,"tasks": {"T-001":{"title":"[T-006] Publish npm package","status":"blocked","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP"},"T-002":{"title":"[T-014] Add CLI integration tests for bin/aahp.js [high]","status":"ready","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"ready","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, v3.5.0, claude-opus-4-8): Release prep. Added the `documentation` pipeline phase (aahp-manifest.sh validation + schema last_session.phase enum + bin/aahp.js help). Fixed aahp-manifest.sh to preserve the optional `cross_repo_ref` field across regeneration (README 10.2 caveat dropped). Added CHANGELOG.md documenting the real version history (npm publishing had lapsed after 3.2.1, so 3.3.0/3.4.0 were never published). Bumped npm 3.4.0 -> 3.5.0. Pointed the CI release notes at CHANGELOG.md. Re-enabled AAHP CI + CodeQL on GitHub-hosted (NOT self-hosted: AAHP is public, so self-hosting risks fork-PR RCE). This manifest was regenerated with the new --phase documentation.
+
 # AAHP: Current State of the Nation
 
 > Last updated: 2026-07-14 by claude-opus-4-8 (branch docs/t010-handoff-sync)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           shellcheck -x -P scripts/ scripts/aahp-manifest.sh
           shellcheck -x -P scripts/ scripts/aahp-migrate-v2.sh
           shellcheck -x -P scripts/ scripts/aahp-migrate-grounding.sh
-          shellcheck scripts/lint-handoff.sh
+          shellcheck -x -P scripts/ scripts/lint-handoff.sh
           shellcheck -x -P scripts/ scripts/verify-handoff.sh
           shellcheck -x -P scripts/ scripts/aahp-archive.sh
           shellcheck scripts/install-hooks.sh
@@ -95,6 +95,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "AAHP $GITHUB_REF_NAME" --notes "Release $GITHUB_REF_NAME. See the README changelog."
+        run: gh release create "$GITHUB_REF_NAME" --title "AAHP $GITHUB_REF_NAME" --notes "Release $GITHUB_REF_NAME. See CHANGELOG.md for details."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to `@elvatis_com/aahp` are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and the project uses semantic
+versioning (`aahp_version` in `MANIFEST.json` tracks the file-format contract and moves
+independently of the npm version).
+
+> Publishing note: npm releases lapsed after `3.2.1` because the CI publish workflow was
+> disabled, so `3.3.0` and `3.4.0` were developed in the repository but never published.
+> `3.5.0` is the first npm release since `3.2.1` and ships everything below it.
+
+## [3.5.0] - 2026-07-14
+
+### Added
+- `documentation` pipeline phase, accepted by `aahp manifest --phase documentation`, the
+  schema `last_session.phase` enum, the manifest generator, and the CLI help.
+- This CHANGELOG. The GitHub release job references it.
+
+### Fixed
+- `aahp-manifest.sh` now preserves the optional `cross_repo_ref` field across
+  regeneration (previously it was dropped), the same way it preserves `project`,
+  `tasks`, and `next_task_id`.
+
+## [3.4.0] - 2026-07-14
+
+### Added
+- README Section 9, Consuming Harness Integration: the harness-vs-AAHP boundary and
+  decision matrix, a reference Claude Code `.claude/` layout, the minimal harness
+  bootstrap, and grounding-audit integration.
+- README Section 10, Multi-Repo and Cross-Repo Handoff, including the optional additive
+  `cross_repo_ref` MANIFEST field (`repo` / `commit` / `handoff_file` / `relation`) and
+  its schema entry, plus monorepo and version-skew doctrine.
+- `aahp status` command documentation and an eight-command CLI reference table (7.1).
+- A condensed inline Grounding reference in Section 2.10 (task-type anchor matrix,
+  confidence bands, minimum TRUST fields).
+
+## [3.3.0] - 2026-07-13
+
+### Added
+- Grounded Reflection Layer (Draft v0.1, README Section 2.10): an orthogonal provenance
+  axis (`model_claim` to `human_confirmed`) recorded as a TRUST.md column, a
+  `templates/GROUNDING.md` task-type anchor matrix scaffolded by `aahp init`, an optional
+  pre-handoff Phase 4.5 grounding audit, and the `aahp migrate-grounding` verb. Additive
+  and backward compatible: no MANIFEST field or schema change.
+
+## [3.2.1] - 2026-06-26
+
+### Fixed
+- Follow-up fixes to the LOG archive flow and the verify gate. Last version published to
+  npm before the 3.5.0 catch-up release.
+
+## [3.2.0] - 2026-06-26
+
+### Added
+- Canonical LOG archive flow: `LOG.md` keeps the 10 newest entries and older entries
+  rotate into `LOG-ARCHIVE.md`; `LOG-ARCHIVE.index.json` records archived-entry hashes so
+  `aahp archive --verify` detects truncation or tampering. Reusable per-check badge
+  workflows were split out for downstream repos.
+
+## [3.1.0] - 2026-06
+
+### Added
+- Reviewed, exact-value, expiring PII email allowlist (`pii-allowlist.json`),
+  MANIFEST-indexed so it cannot suppress secrets. Shipped to npm as part of the 3.2.0
+  release.
+
+## [3.0.1] to [3.0.5] - 2026-04-12 to 2026-06-20
+
+### Added
+- AAHP v3: stable task IDs (`T-001` and up), a machine-readable dependency graph in
+  `MANIFEST.json`, the `aahp` CLI, the verify gate (`aahp verify`), checksum integrity,
+  the prompt-injection and secrets/PII firewalls, and OIDC trusted publishing to npm.
+
+### Changed
+- Relicensed to Apache-2.0 (earlier commits carried MIT, then CC BY 4.0, headers).
+
+[3.5.0]: https://github.com/homeofe/AAHP/releases/tag/v3.5.0
+[3.4.0]: https://github.com/homeofe/AAHP/compare/v3.2.1...v3.4.0
+[3.3.0]: https://github.com/homeofe/AAHP/compare/v3.2.1...v3.3.0
+[3.2.1]: https://github.com/homeofe/AAHP/releases/tag/v3.2.1
+[3.2.0]: https://github.com/homeofe/AAHP/releases/tag/v3.2.0

--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ The reference is an optional, additive top-level field in B's `MANIFEST.json`:
 - `handoff_file` (optional): path to the referenced handoff file; defaults to `.ai/handoff/MANIFEST.json`.
 - `relation` (required): one of `implements`, `extends`, `consumes` -how B relates to A.
 
-This field is **optional and backward compatible**. The manifest schema (`schema/aahp-manifest.schema.json`, npm v3.4) permits it but does not require it, so v2 and v3 projects without it validate and run unchanged. It is agent-set, like the task graph: an agent adds it when a cross-repo relation exists and (as with `tasks`) re-adds it after a manifest regeneration until the generator preserves it natively.
+This field is **optional and backward compatible**. The manifest schema (`schema/aahp-manifest.schema.json`) permits it but does not require it, so v2 and v3 projects without it validate and run unchanged. It is agent-set, like the task graph: an agent adds it when a cross-repo relation exists, and `aahp-manifest.sh` preserves it across regeneration (the same way it preserves `project`, `tasks`, and `next_task_id`).
 
 ### 10.3 Monorepo considerations
 
@@ -961,6 +961,12 @@ When a consumer runs older scripts than the upstream ships, the mismatch is safe
 ---
 
 *This specification is a living document. Feedback welcome at [github.com/homeofe/AAHP](https://github.com/homeofe/AAHP).*
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 ---
 

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -63,7 +63,7 @@ Init options:
 Manifest options:
   --agent NAME      Agent identifier (default: "cli-tool")
   --session-id ID   Session identifier (default: auto-generated)
-  --phase PHASE     Pipeline phase: research|architecture|implementation|review|fix|idle
+  --phase PHASE     Pipeline phase: research|architecture|implementation|review|fix|idle|documentation
   --context "TEXT"  Quick context string
   --duration MIN    Session duration in minutes
   --quiet           Suppress output except errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aahp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aahp",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "bin": {
         "aahp": "bin/aahp.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvatis_com/aahp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "AI-to-AI Handoff Protocol - CLI tools for managing agent handoff files",
   "author": "Elvatis <emre.kohler@elvatis.com>",
   "bin": {

--- a/schema/aahp-manifest.schema.json
+++ b/schema/aahp-manifest.schema.json
@@ -55,7 +55,8 @@
             "implementation",
             "review",
             "fix",
-            "idle"
+            "idle",
+            "documentation"
           ],
           "description": "Pipeline phase at session end"
         },

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --agent NAME       Agent identifier (default: "cli-tool")
 #   --session-id ID    Session identifier (default: auto-generated)
-#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle (default: "idle")
+#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle|documentation (default: "idle")
 #   --context "TEXT"    Quick context string (default: auto-generated from file summaries)
 #   --duration MIN     Session duration in minutes (default: 0)
 #   --quiet            Suppress output except errors
@@ -67,9 +67,9 @@ fi
 
 # Validate phase
 case "$PHASE" in
-    research|architecture|implementation|review|fix|idle) ;;
+    research|architecture|implementation|review|fix|idle|documentation) ;;
     *)
-        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle" >&2
+        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle, documentation" >&2
         exit 1
         ;;
 esac
@@ -140,6 +140,7 @@ FULL_TOKENS=$((MANIFEST_TOKENS + TOTAL_TOKENS))
 
 TASKS_JSON=""
 NEXT_TASK_ID=""
+CROSS_REPO_REF=""
 
 if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
@@ -157,6 +158,15 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
         " 2>/dev/null || true)
         if [ -n "$EXISTING_ID" ] && [[ "$EXISTING_ID" =~ ^[0-9]+$ ]]; then
             NEXT_TASK_ID="$EXISTING_ID"
+        fi
+        # Preserve the optional cross_repo_ref field (v3.4+), like tasks it is
+        # agent-managed and must survive regeneration.
+        EXISTING_CRR=$(node -e "
+            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            if (m.cross_repo_ref) process.stdout.write(JSON.stringify(m.cross_repo_ref));
+        " 2>/dev/null || true)
+        if [ -n "$EXISTING_CRR" ]; then
+            CROSS_REPO_REF="$EXISTING_CRR"
         fi
     fi
 fi
@@ -192,6 +202,9 @@ MANIFEST
     fi
     if [ -n "$TASKS_JSON" ]; then
         echo "  ,\"tasks\": $TASKS_JSON"
+    fi
+    if [ -n "$CROSS_REPO_REF" ]; then
+        echo "  ,\"cross_repo_ref\": $CROSS_REPO_REF"
     fi
 
     echo "}"

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -176,7 +176,7 @@ if [ -n "$EMAIL_MATCHES" ]; then
     while IFS= read -r match; do
         address="${match##*:}"
         allowed=0
-        while IFS=$'\t' read -r value owner expires reason; do
+        while IFS=$'\t' read -r value owner expires _; do
             [ -z "$value" ] && continue
             if [ "$address" = "$value" ]; then
                 echo -e "  ${GREEN}OK Allowed PII email '$address' via pii-allowlist.json (owner: $owner, expires: $expires).${NC}"


### PR DESCRIPTION
feat(release): documentation phase + cross_repo_ref preservation (v3.5.0)

- Add the `documentation` pipeline phase to aahp-manifest.sh (validation),
  the schema last_session.phase enum, and the CLI help (bin/aahp.js).
- Preserve the optional cross_repo_ref MANIFEST field across regeneration in
  aahp-manifest.sh (it was previously dropped), the same way project/tasks/
  next_task_id are preserved; update README 10.2 accordingly.
- Add CHANGELOG.md. npm publishing had lapsed after 3.2.1 (the CI publish
  workflow was disabled), so 3.3.0 and 3.4.0 were never published; document
  the full history and point the CI release notes at CHANGELOG.md.
- Bump npm version 3.4.0 -> 3.5.0 (package.json + package-lock.json).

Verified locally: `aahp manifest --phase documentation` succeeds; cross_repo_ref
survives regeneration; ajv accepts the documentation phase; bats suite green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
