### PR TITLE
fix(portability): one bash resolver for the CLI and the dashboard

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,23 +2,23 @@
   "aahp_version": "3.0",
   "project": "AAHP",
   "last_session": {
-    "agent": "grok-4.5",
-    "session_id": "cli-1785783933",
-    "timestamp": "2026-08-03T19:05:33Z",
-    "commit": "ed75ba4",
-    "phase": "implementation",
+    "agent": "claude-opus-5",
+    "session_id": "cli-1785924628",
+    "timestamp": "2026-08-05T10:10:28Z",
+    "commit": "9207aab",
+    "phase": "idle",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:68e01e1a49f03dc8d6ce7bd8e87b9eccd970fc77ef9580dfa9dd23aca845e0eb",
-      "updated": "2026-08-03T19:05:32Z",
-      "lines": 112,
+      "checksum": "sha256:ec6177f81bc982bb5036bbebd54cbf58de251bd2a987df34e0876c1f3162777f",
+      "updated": "2026-08-05T09:55:45Z",
+      "lines": 131,
       "summary": "AAHP **v3.9.1** (npm `@elvatis_com/aahp`). File-based AI-to-AI handoff protocol plus CLI"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:25bd60fc7675be3defec2d612178aedf2da05c6bc3b2f24fb24a2d44a2fbc1d7",
-      "updated": "2026-08-03T18:53:11Z",
+      "updated": "2026-08-03T19:09:11Z",
       "lines": 217,
       "summary": "Current version: **v3.9.1**"
     },
@@ -48,7 +48,7 @@
     },
     "TRUST.md": {
       "checksum": "sha256:91f124fe10a934779ef1d7442dd54af6656bbc03c4b1cde13a9d4cac9ab248e6",
-      "updated": "2026-08-03T18:53:11Z",
+      "updated": "2026-08-03T19:09:11Z",
       "lines": 93,
       "summary": "| Level | Meaning |"
     },
@@ -60,7 +60,7 @@
     },
     "WORKFLOW.md": {
       "checksum": "sha256:ef005f24e399791abb986b3a76403295c33ad3b28bb9b7dc777d1d0528b31151",
-      "updated": "2026-08-03T18:52:12Z",
+      "updated": "2026-08-03T19:09:11Z",
       "lines": 156,
       "summary": "| Agent | Model | Role | Responsibility |"
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "AAHP v3.9.1. Doctor handoff-set fails on partial index. Handoff hygiene closed for issues 56-61. nonnpm-root fixtures write files before indexing.",
+  "quick_context": "AAHP **v3.9.1** (npm `@elvatis_com/aahp`). File-based AI-to-AI handoff protocol plus CLI Current version: **v3.9.1** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3494,
-    "full_read": 13564
+    "manifest_plus_core": 4129,
+    "full_read": 14199
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,6 +1,6 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-08-03 by grok-4.5
+> Last updated: 2026-08-05 by claude-opus-5
 > Commit: (pending this branch)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
@@ -22,9 +22,27 @@ Shipped surface (high level):
   Layer (TRUST provenance + GROUNDING.md), optional Phase 4.5 in WORKFLOW
 - **Ops:** `aahp status`, `aahp archive`, OIDC npm publish on semver tags, badge workflows
 
-This session (2026-08-03) closes handoff hygiene drift found by a flawed external
-"cross-check": STATUS rewrite, MANIFEST summaries, WORKFLOW alignment, TRUST re-verify,
-NEXT_ACTIONS dedupe, and doctor `handoff-set` alignment with Layer 1 on partial indexes.
+This session (2026-08-05) fixes a Windows-only defect in `handoff-refresh` and removes the
+duplication that caused it. `aahp-dashboard.mjs` shelled out to a bare `bash` with native
+backslash paths. Both halves fail on Windows: bash eats the backslashes as escapes, and a
+bare `bash` can resolve to the WSL launcher, which has no `C:` drive. `LOG.md` is written
+before the regen, so the failure leaves MANIFEST checksums stale against the file just
+produced.
+
+The root cause was a second implementation: `bin/aahp.js` already solved this (its comment
+reads "prefer Git Bash over the WSL bash shim and avoid raw C:\... script arguments") with
+its own `findBashExecutable()`/`toBashScriptArg()`, and the dashboard call site had neither
+and knew nothing of them. There is now ONE implementation in `aahp-config.mjs`, used by
+both, merging what each side got right, plus a test that fails if a copy reappears.
+
+Provenance, stated precisely: found while fixing the identical pattern in
+supply-chain-guard, which runs a **divergent local fork** of this script whose bash call
+has no `generate.log` guard and is therefore always reachable. SCG does not configure
+`generate.log` and does not consume the packaged dashboard in write mode, so it is not a
+consumer of this fix. The upstream defect was reproduced directly against a
+consumer-shaped fixture. Upstream the call is reached only in write mode by a consumer
+that configures `generate.log`; `--check` exits before it. This is therefore a correctness
+fix ahead of a field report, not a response to one.
 <!-- /SECTION: summary -->
 
 ---
@@ -41,7 +59,9 @@ NEXT_ACTIONS dedupe, and doctor `handoff-set` alignment with Layer 1 on partial 
 | `nonnpm-root.bats` | OK | 11 tests; fixtures write handoff files before indexing (partial-index alignment) |
 | `lint.bats` | OK | 39 tests incl conflict-marker coverage (CI green on #55) |
 | `verify.bats` | OK | 22 tests (CI authoritative for full suite) |
-| `gates.bats` | OK | 22 tests |
+| `gates.bats` | OK | 22 tests; re-run this session (test 22 exercises the dashboard write path) |
+| `bash-portability.bats` | OK | 13 tests, new; 12 pass + 1 skip on Git Bash (stand-in interpreter needs a POSIX shebang) |
+| `aahp manifest` / `lint` / `verify` | OK | re-run after routing `bin/aahp.js` through the shared helpers; all exit 0 on Windows |
 | `acceptance-criteria.bats` | OK | 66 tests |
 | `cli.bats` | PARTIAL local | known Windows-only flakes; green on Linux CI |
 | `npm run check` | OK | 8 config-driven gates |
@@ -63,7 +83,8 @@ NEXT_ACTIONS dedupe, and doctor `handoff-set` alignment with Layer 1 on partial 
 | Conflict markers | `scripts/check-conflict-markers.mjs` | Complete | CRLF-safe; bash/grep fallback |
 | Doctor | `bin/aahp.js` cmdDoctor | Complete | handoff-set matches Layer 1 partial-index rule |
 | Release gates | `scripts/check-*.mjs` | Complete | version-sync, changelog, claims, forbidden-patterns, schema-doc-sync, doc-links |
-| Dashboard check | `scripts/aahp-dashboard.mjs` | Complete | handoff freshness |
+| Dashboard check | `scripts/aahp-dashboard.mjs` | Complete | handoff freshness; bash call goes through `resolveBash`/`toBashPath` |
+| Shared config lib | `scripts/aahp-config.mjs` | Complete | root/pkg/config resolution, git enumeration, bash interpreter + path portability |
 | Manifest gen | `scripts/aahp-manifest.sh` | Complete | preserves tasks / next_task_id / cross_repo_ref |
 | Archive | archive command | Complete | keep 10 newest LOG entries |
 | Schemas | `schema/` | Complete | manifest, config, pii-allowlist |
@@ -84,6 +105,9 @@ NEXT_ACTIONS dedupe, and doctor `handoff-set` alignment with Layer 1 on partial 
 | Template/dogfood DASHBOARD staleness | LOW | DASHBOARD.md still shows early v2 task rows; selection authority is MANIFEST `tasks` (see WORKFLOW). Cosmetic. |
 | Long LOG entry bodies | LOW | LOG.md is at the 10-entry cap with long bodies (~250 lines). Protocol entry count is satisfied; optional future trim of body length only. |
 | Windows full-suite speed | LOW | Full bats is hours on this host; Linux CI / openclaw is the full-suite authority. |
+| No Windows CI runner | MEDIUM | CI is `ubuntu-latest` only, so no job executes the shipped bash tooling under Git Bash. This is how the `handoff-refresh` interpreter defect reached a consumer. Mitigated but not closed: `resolveBash`/`toBashPath` take `platform`/`env` as parameters, so their win32 behaviour is asserted on the Linux runner. A `windows-latest` bats job would cover the remaining surface (`_aahp-lib.sh`, `verify-handoff.sh`, `lint-handoff.sh`), and is a larger change than this fix. |
+| Consumer-only code paths untested | MEDIUM | AAHP configures only `generate.freshness`, so `writeLog()` returns before the bash call and AAHP's own dogfooding never executes it. Any AAHP-only gate run, on any platform, is blind to that branch. Coverage has to come from a consumer-shaped fixture. |
+| `aahp-manifest.sh` clobbers `project` on regeneration | MEDIUM | `PROJECT_NAME=$(basename ...)` is unconditional (`scripts/aahp-manifest.sh`), so regenerating inside a differently-named checkout (temp dir, CI dir, tarball) overwrites a consumer's real project name. supply-chain-guard already carries the fix (preserve the existing MANIFEST `project`, derive from basename only on first generation) and it was never upstreamed. The estate's most-depended-upon repo is the one carrying the bug. Not fixed here to keep this PR to one concern. |
 <!-- /SECTION: what_is_missing -->
 
 ---
@@ -92,21 +116,16 @@ NEXT_ACTIONS dedupe, and doctor `handoff-set` alignment with Layer 1 on partial 
 
 | Item | Resolution |
 |------|------------|
-| PR #55 conflict markers | Merged: lint check 7 fails closed on `<<<<<<<` / `=======` / `>>>>>>>` |
-| STATUS append-log drift (#56) | Rewrote to current-state snapshot (this file) |
-| MANIFEST null summaries (#57) | Regenerated with meaningful quick_context + auto_summary depth fix |
-| LOG "exceeds 10" claim (#58) | Closed as incorrect: exactly 10 entries (at cap, not over) |
-| WORKFLOW drift (#59) | Phase 4.5, harness-owned models, MANIFEST task selection |
-| Doctor partial index (#60.1) | handoff-set fails when canonical file present but not indexed |
-| TRUST TTL drift (#60.2) | Re-verification sweep 2026-08-03 |
-| NEXT_ACTIONS duplicate sections (#60.3) | Single Recently Completed section, max 5 |
-| Perplexity meta-audit (#61) | Closed as non-evidence (model identity faked; rubber-stamped false #58) |
+| `handoff-refresh` MANIFEST regen fails on Windows | `resolveBash()` prefers an installed Git Bash over a bare PATH lookup; `toBashPath()` normalises separators. `AAHP_BASH` still overrides both. |
+| Windows behaviour untestable on Linux CI | Helpers take `platform`/`env` as parameters, so `tests/bash-portability.bats` asserts the win32 paths deterministically on `ubuntu-latest`. |
 
 ---
 
 ## Trust Levels
 
-- **(Verified):** doctor handoff-set fails on partial index (new doctor.bats regression); conflict-marker check shipped in #55.
-- **(Verified):** handoff rewrite + MANIFEST regeneration + `aahp verify --level prepush` this session.
-- **(Assumed):** full suite green on Linux CI after push (not re-run locally end-to-end).
+- **(Verified):** the defect reproduces on Windows with unmodified 3.9.1 against a consumer-shaped config (`generate.log` set). Observed: `/bin/bash: C:UsersrootworkspaceAAHPscriptsaahp-manifest.sh: No such file or directory`, with the separators stripped and the interpreter resolved to WSL.
+- **(Verified):** mutation proof on the new suite. Reverting both helpers to their pre-fix behaviour turns exactly the two defect-specific tests red; restoring turns them green.
+- **(Verified):** `gates.bats` 22/22 and `npm run check` green after the change; `handoff-refresh` completes end-to-end on the consumer fixture and now resolves an absolute Git Bash rather than relying on PATH order.
+- **(Assumed):** full suite green on Linux CI after push (only the two affected suites were run locally).
+- **(Known gap):** no Windows CI runner, and AAHP's own config cannot reach the fixed code path (see What is Missing).
 - **(Known gap):** delete-both-sides Layer 1 hole remains (see What is Missing).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ independently of the npm version).
 
 ## [Unreleased]
 
+### Fixed
+- `handoff-refresh` no longer fails on Windows when it regenerates `MANIFEST.json`.
+  `aahp-dashboard.mjs` shelled out to a bare `bash` with native backslash paths, which
+  breaks in two independent ways: bash consumes each backslash as an escape, and a bare
+  `bash` on Windows can resolve to `C:\Windows\System32\bash.exe` (the WSL launcher),
+  whose filesystem has no `C:` drive. `LOG.md` is written before the regen, so the failure
+  left the manifest checksums stale against the file just produced. Only a project that
+  configures `generate.log` reaches this code path, and only in write mode (`--check` exits
+  before it), which is why AAHP's own dogfooding never hit it.
+
+### Changed
+- Bash interpreter resolution and Windows path conversion now have a single implementation,
+  `resolveBash()` and `toBashPath()` in `aahp-config.mjs`, used by both `bin/aahp.js` and
+  `scripts/aahp-dashboard.mjs`. `bin/aahp.js` previously carried its own
+  `findBashExecutable()`/`toBashScriptArg()` pair; the dashboard call site had neither, so
+  the same Windows defect had to be found a second time. The merged helper keeps what each
+  side got right: the relative-path and `/c/` MSYS strategies from the CLI, and the
+  `AAHP_BASH` override plus environment-driven candidate paths (including Git's `usr/bin`
+  layout and per-user `LOCALAPPDATA` installs) from the new one. `platform`, `env` and `cwd`
+  are injectable, so the win32 behaviour is asserted on the Linux CI runner
+  (`tests/bash-portability.bats`), and a test fails if a second copy is reintroduced.
+
 ## [3.9.1] - 2026-08-03
 **Doctor handoff-set matches Layer 1 on partial indexes; handoff hygiene**
 

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -23,9 +23,10 @@
 //   --version, -v     Show version number
 
 import { fileURLToPath } from 'node:url'
-import { dirname, join, resolve, relative, isAbsolute } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { existsSync, mkdirSync, copyFileSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { spawn, spawnSync } from 'node:child_process'
+import { resolveBash, toBashPath } from '../scripts/aahp-config.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -889,36 +890,11 @@ function cmdCriteria(targetPath) {
 // We pass the arguments through directly so the scripts see them unchanged.
 // ---------------------------------------------------------------------------
 
-function toBashScriptArg(scriptPath) {
-  if (process.platform !== 'win32') {
-    return scriptPath
-  }
-
-  const relativePath = relative(process.cwd(), scriptPath)
-  if (relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath)) {
-    return relativePath.replace(/\\/g, '/')
-  }
-
-  const drivePath = scriptPath.match(/^([A-Za-z]):\\(.*)$/)
-  if (drivePath) {
-    return `/${drivePath[1].toLowerCase()}/${drivePath[2].replace(/\\/g, '/')}`
-  }
-
-  return scriptPath.replace(/\\/g, '/')
-}
-
-function findBashExecutable() {
-  if (process.platform !== 'win32') {
-    return 'bash'
-  }
-
-  const candidates = [
-    'C:\\Program Files\\Git\\bin\\bash.exe',
-    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
-    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
-  ]
-  return candidates.find((candidate) => existsSync(candidate)) ?? 'bash'
-}
+// Path conversion and bash resolution live in scripts/aahp-config.mjs so this
+// file and scripts/aahp-dashboard.mjs cannot drift apart. They used to be two
+// separate implementations: this one knew about relative paths and the /c/ MSYS
+// form but not AAHP_BASH, while the dashboard call site knew neither. The same
+// Windows defect then had to be found twice.
 
 function runScript(scriptName, rest) {
   const scriptPath = join(PACKAGE_ROOT, 'scripts', scriptName)
@@ -930,8 +906,10 @@ function runScript(scriptName, rest) {
 
   // Pass all arguments after the subcommand directly to the bash script.
   // On Windows, prefer Git Bash over the WSL bash shim and avoid raw C:\... script arguments.
-  const args = [toBashScriptArg(scriptPath), ...rest]
-  const bashExecutable = findBashExecutable()
+  // The child spawns with cwd: process.cwd() below, so toBashPath's default cwd
+  // is the right one here and must not be overridden.
+  const args = [toBashPath(scriptPath), ...rest]
+  const bashExecutable = resolveBash()
 
   const child = spawn(bashExecutable, args, {
     stdio: 'inherit',

--- a/scripts/aahp-config.mjs
+++ b/scripts/aahp-config.mjs
@@ -8,7 +8,7 @@
 // used by the bash tooling: an optional [path] first positional, default ".".
 
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join, resolve, relative, isAbsolute } from "node:path";
 import { execFileSync } from "node:child_process";
 
 // Resolve the target project root: the first non-flag positional argument,
@@ -96,4 +96,73 @@ export function listTrackedFiles(root, specs) {
     maxBuffer: 64 * 1024 * 1024,
   });
   return out.split("\0").filter(Boolean);
+}
+
+// Convert a filesystem path into a form a POSIX shell reads correctly.
+//
+// On Windows a native path is backslash-separated, and bash consumes each
+// backslash as an escape character: "C:\Users\x\s.sh" reaches the interpreter
+// as "C:Usersxs.sh" and fails with "No such file or directory".
+//
+// Three strategies, most robust first:
+//   1. A path under `cwd` becomes relative, which sidesteps the drive-letter
+//      question entirely and so works under any bash flavour.
+//   2. An absolute drive path becomes the MSYS form Git Bash understands
+//      (C:\x -> /c/x).
+//   3. Anything else has its separators swapped.
+//
+// Off win32 this is a no-op, because a backslash is a legal character in a
+// POSIX filename and rewriting it would corrupt a valid path.
+//
+// `cwd` MUST be the working directory the child process will run in, which is
+// not always process.cwd(). Pass it explicitly when they differ, or strategy 1
+// yields a path relative to the wrong directory.
+//
+// Caveat for callers passing an explicit `platform`: the relative/absolute
+// tests use the HOST's path semantics, so on a non-Windows host strategy 1 can
+// engage where a real Windows run would fall through to strategy 2. Tests that
+// need a specific strategy should pass a `cwd` that forces it.
+export function toBashPath(p, platform = process.platform, cwd = process.cwd()) {
+  if (platform !== "win32") return String(p);
+  const s = String(p);
+  const rel = relative(cwd, s);
+  if (rel && !rel.startsWith("..") && !isAbsolute(rel)) return rel.replace(/\\/g, "/");
+  const drive = s.match(/^([A-Za-z]):\\(.*)$/);
+  if (drive) return `/${drive[1].toLowerCase()}/${drive[2].replace(/\\/g, "/")}`;
+  return s.replace(/\\/g, "/");
+}
+
+// Resolve the bash interpreter used to run the POSIX helper scripts.
+//
+// AAHP_BASH always wins, so a consumer can pin a specific interpreter.
+// Off win32, "bash" from PATH is correct and is returned unchanged.
+//
+// On Windows, "bash" from PATH is NOT reliably a POSIX shell. A default Git for
+// Windows install puts only Git's cmd/ directory on PATH, which carries git.exe
+// but not bash.exe, while Windows itself ships C:\Windows\System32\bash.exe:
+// the WSL launcher. PATH order then resolves a bare "bash" to WSL, whose root
+// filesystem has no C: drive, so a Windows-shaped script path cannot be opened
+// at all and the call fails no matter how the path is spelled. Prefer an
+// explicit Git Bash, and fall back to "bash" when none is found so the failure
+// stays the caller's to report rather than being masked here.
+//
+// The candidate list is driven by environment variables rather than hardcoded
+// to "C:\Program Files", so a Git install on another drive is still found, and
+// covers both the machine-wide and the per-user (LOCALAPPDATA) install layouts
+// as well as Git's usr/bin location.
+//
+// env and platform are injectable so the win32 behaviour is testable on any
+// host, including the Linux CI runner.
+export function resolveBash(env = process.env, platform = process.platform) {
+  if (env.AAHP_BASH) return env.AAHP_BASH;
+  if (platform !== "win32") return "bash";
+  const pf = env.ProgramFiles || "C:\\Program Files";
+  const pf86 = env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+  const candidates = [
+    join(pf, "Git", "bin", "bash.exe"),
+    join(pf, "Git", "usr", "bin", "bash.exe"),
+    join(pf86, "Git", "bin", "bash.exe"),
+    ...(env.LOCALAPPDATA ? [join(env.LOCALAPPDATA, "Programs", "Git", "bin", "bash.exe")] : []),
+  ];
+  return candidates.find((c) => existsSync(c)) || "bash";
 }

--- a/scripts/aahp-dashboard.mjs
+++ b/scripts/aahp-dashboard.mjs
@@ -38,7 +38,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { basename, dirname, join } from "node:path";
-import { resolveRoot, loadPkg, loadConfig } from "./aahp-config.mjs";
+import { resolveRoot, loadPkg, loadConfig, resolveBash, toBashPath } from "./aahp-config.mjs";
 import { parseReleases } from "./changelog-grammar.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -166,10 +166,25 @@ if (isCheck) {
   writeFileSync(target, content);
   // Regenerate MANIFEST.json so its checksums match the file we just wrote.
   // Delegate to the canonical writer (sibling script), overridable via AAHP_BASH.
+  //
+  // The interpreter and both path arguments go through the helpers rather than
+  // being passed raw: on Windows a bare "bash" can resolve to the WSL launcher,
+  // which cannot see the C: drive, and native backslash paths are eaten as
+  // escapes by any bash. See resolveBash/toBashPath in aahp-config.mjs.
   try {
     execFileSync(
-      process.env.AAHP_BASH || "bash",
-      [join(scriptDir, "aahp-manifest.sh"), root, "--agent", "handoff-refresh", "--phase", "idle", "--quiet"],
+      resolveBash(),
+      [
+        // The child spawns with cwd: root below, so root - not process.cwd() -
+        // is the base a relative path must be computed against.
+        toBashPath(join(scriptDir, "aahp-manifest.sh"), process.platform, root),
+        toBashPath(root, process.platform, root),
+        "--agent",
+        "handoff-refresh",
+        "--phase",
+        "idle",
+        "--quiet",
+      ],
       { stdio: "inherit", cwd: root },
     );
   } catch (err) {

--- a/tests/bash-portability.bats
+++ b/tests/bash-portability.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# bash-portability.bats - Windows-safe resolution of the bash interpreter and
+# of the paths handed to it.
+#
+# aahp-dashboard.mjs is the ONLY place in AAHP that shells out to bash (every
+# other execFileSync runs `git` or process.execPath, both native binaries that
+# accept Windows paths as-is). It ran `process.env.AAHP_BASH || "bash"` with
+# raw join() paths, which fails on Windows in two independent ways:
+#
+#   1. A native path is backslash-separated and bash consumes each backslash as
+#      an escape, so "C:\Users\x\s.sh" arrives as "C:Usersxs.sh".
+#   2. A bare "bash" is not reliably a POSIX shell. A default Git for Windows
+#      install puts only Git's cmd/ on PATH (git.exe, not bash.exe), while
+#      Windows ships C:\Windows\System32\bash.exe: the WSL launcher. PATH order
+#      then selects WSL, which has no C: drive and cannot open the script at
+#      all, however the path is spelled.
+#
+# Observed failure, AAHP 3.9.1 on Windows against a consumer-shaped config:
+#   /bin/bash: C:UsersrootworkspaceAAHPscriptsaahp-manifest.sh:
+#   No such file or directory
+#   .ai/handoff/LOG.md was written, but MANIFEST.json regen failed
+# Note both defects are visible at once: the separators are gone AND the
+# interpreter is WSL's /bin/bash.
+#
+# This never surfaced in AAHP's own dogfooding because AAHP sets only
+# generate.freshness, so writeLog() returns at the "no generate.log configured"
+# early exit (aahp-dashboard.mjs) BEFORE reaching the bash call. Only a consumer
+# that configures generate.log executes it. A Windows CI job on AAHP alone would
+# therefore still not cover this, which is why resolveBash/toBashPath take
+# platform and env as parameters: the win32 behaviour is asserted here
+# deterministically on the Linux runner.
+
+load test_helper
+
+CFG="$SCRIPTS_DIR/aahp-config.mjs"
+DASH="$SCRIPTS_DIR/aahp-dashboard.mjs"
+
+# Evaluate an expression against the exported helpers and print the result.
+#
+# The body is written to a file and the module path is passed as argv, then
+# converted with pathToFileURL. Passing it as an import specifier would break
+# under Git Bash, where $SCRIPTS_DIR is a POSIX path that node cannot resolve;
+# argv is mangled to a native path by MSYS, and pathToFileURL normalises both.
+#
+# Backslashes are produced with String.fromCharCode(92) rather than written
+# literally so that no shell or heredoc layer can reinterpret them.
+probe() {
+    {
+        echo "import { pathToFileURL } from 'node:url';"
+        echo "const { toBashPath, resolveBash } = await import(pathToFileURL(process.argv[2]).href);"
+        echo "const BS = String.fromCharCode(92);"
+        echo "$1"
+    } > "$TEST_TMPDIR/probe.mjs"
+    node "$TEST_TMPDIR/probe.mjs" "$CFG"
+}
+
+# --- toBashPath --------------------------------------------------------------
+
+# Every toBashPath test passes an explicit cwd. relative()/isAbsolute() use the
+# HOST's path semantics regardless of the `platform` argument, so an implicit
+# cwd makes the chosen strategy depend on where the suite runs. Each test below
+# pins one strategy with a cwd that selects it identically on Linux and Windows.
+
+@test "toBashPath: strategy 1 prefers a relative path, which needs no drive letter" {
+    run probe 'console.log(toBashPath("/repo/scripts/m.sh", "win32", "/repo"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/m.sh" ]
+}
+
+@test "toBashPath: strategy 2 converts a drive path to the MSYS form bash understands" {
+    run probe 'console.log(toBashPath("C:" + BS + "Users" + BS + "x" + BS + "s.sh", "win32", "C:" + BS + "Other"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = "/c/Users/x/s.sh" ]
+}
+
+@test "toBashPath: strategy 3 leaves an already-forward-slashed path untouched" {
+    run probe 'console.log(toBashPath("C:/already/forward.sh", "win32", "C:" + BS + "Other"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = "C:/already/forward.sh" ]
+}
+
+@test "toBashPath: is a no-op off win32, where a backslash is a legal filename character" {
+    run probe 'console.log(toBashPath("/tmp/odd" + BS + "name.sh", "linux", "/tmp"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = '/tmp/odd\name.sh' ]
+}
+
+# --- resolveBash -------------------------------------------------------------
+
+@test "resolveBash: AAHP_BASH wins on win32" {
+    run probe 'console.log(resolveBash({ AAHP_BASH: "/custom/bash" }, "win32"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = "/custom/bash" ]
+}
+
+@test "resolveBash: AAHP_BASH wins off win32" {
+    run probe 'console.log(resolveBash({ AAHP_BASH: "/custom/bash" }, "linux"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = "/custom/bash" ]
+}
+
+@test "resolveBash: returns PATH bash off win32" {
+    run probe 'console.log(resolveBash({}, "linux"));'
+    [ "$status" -eq 0 ]
+    [ "$output" = "bash" ]
+}
+
+# The candidates are built with join(), which emits the HOST separator, so the
+# raw result differs between a Linux runner and Git Bash. These compare with
+# separators normalised on BOTH sides rather than pinning one spelling, and
+# print the actual value on mismatch.
+
+@test "resolveBash: on win32 prefers an installed Git Bash over the PATH lookup" {
+    mkdir -p "$TEST_TMPDIR/Git/bin"
+    : > "$TEST_TMPDIR/Git/bin/bash.exe"
+    run probe "const got = resolveBash({ ProgramFiles: '$TEST_TMPDIR' }, 'win32');
+const fwd = (s) => s.split(BS).join('/');
+console.log(fwd(got) === fwd('$TEST_TMPDIR/Git/bin/bash.exe') ? 'MATCH' : 'MISMATCH: ' + got);"
+    [ "$status" -eq 0 ]
+    [ "$output" = "MATCH" ]
+}
+
+@test "resolveBash: on win32 finds Git's usr/bin layout too" {
+    mkdir -p "$TEST_TMPDIR/Git/usr/bin"
+    : > "$TEST_TMPDIR/Git/usr/bin/bash.exe"
+    run probe "const got = resolveBash({ ProgramFiles: '$TEST_TMPDIR' }, 'win32');
+const fwd = (s) => s.split(BS).join('/');
+console.log(fwd(got) === fwd('$TEST_TMPDIR/Git/usr/bin/bash.exe') ? 'MATCH' : 'MISMATCH: ' + got);"
+    [ "$status" -eq 0 ]
+    [ "$output" = "MATCH" ]
+}
+
+@test "resolveBash: on win32 finds a per-user Git install via LOCALAPPDATA" {
+    mkdir -p "$TEST_TMPDIR/Programs/Git/bin"
+    : > "$TEST_TMPDIR/Programs/Git/bin/bash.exe"
+    run probe "const got = resolveBash({ ProgramFiles: '$TEST_TMPDIR/absent', LOCALAPPDATA: '$TEST_TMPDIR' }, 'win32');
+const fwd = (s) => s.split(BS).join('/');
+console.log(fwd(got) === fwd('$TEST_TMPDIR/Programs/Git/bin/bash.exe') ? 'MATCH' : 'MISMATCH: ' + got);"
+    [ "$status" -eq 0 ]
+    [ "$output" = "MATCH" ]
+}
+
+@test "resolveBash: on win32 falls back to bash when no Git Bash is installed" {
+    run probe "console.log(resolveBash({ ProgramFiles: '$TEST_TMPDIR/absent' }, 'win32'));"
+    [ "$status" -eq 0 ]
+    [ "$output" = "bash" ]
+}
+
+# --- de-duplication guard ----------------------------------------------------
+
+# bin/aahp.js used to carry its OWN toBashScriptArg/findBashExecutable. That
+# second implementation is why the same Windows defect had to be found twice:
+# the CLI knew about relative paths and the /c/ form, the dashboard call site
+# knew neither, and neither knew about the other. Both now share one
+# implementation, and this test fails if a copy is reintroduced.
+@test "bin/aahp.js does not reimplement bash resolution" {
+    run grep -nE "function (findBashExecutable|toBashScriptArg)" "$AAHP_ROOT/bin/aahp.js"
+    [ "$status" -ne 0 ]
+    run grep -c "from '../scripts/aahp-config.mjs'" "$AAHP_ROOT/bin/aahp.js"
+    [ "$output" -ge 1 ]
+}
+
+# --- wiring: the dashboard actually uses them --------------------------------
+
+# Asserts the argv the dashboard hands to the interpreter. On Linux this pins
+# the wiring (script path and root arrive as two separate, resolvable
+# arguments); run under Git Bash on Windows the same assertions become a direct
+# regression test for defect 1, because an unconverted path would arrive with
+# its separators stripped.
+@test "handoff-refresh: passes a resolvable script path and root to the interpreter" {
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) skip "stand-in interpreter relies on a POSIX shebang" ;;
+    esac
+
+    echo '{ "name": "fx", "version": "1.0.0" }' > "$TEST_TMPDIR/package.json"
+    cat > "$TEST_TMPDIR/aahp.config.json" <<'EOF'
+{ "generate": { "log": { "source": "CHANGELOG.md", "target": ".ai/handoff/LOG.md" } } }
+EOF
+    cat > "$TEST_TMPDIR/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2026-01-01
+**First release**
+
+### Added
+- Initial cut.
+EOF
+
+    # Stand-in interpreter: records argv instead of running the script.
+    cat > "$TEST_TMPDIR/fakebash" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$AAHP_ARGV_OUT"
+EOF
+    chmod +x "$TEST_TMPDIR/fakebash"
+
+    export AAHP_BASH="$TEST_TMPDIR/fakebash"
+    export AAHP_ARGV_OUT="$TEST_TMPDIR/argv.txt"
+    run node "$DASH" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+
+    local script_arg root_arg
+    script_arg="$(sed -n '1p' "$TEST_TMPDIR/argv.txt")"
+    root_arg="$(sed -n '2p' "$TEST_TMPDIR/argv.txt")"
+
+    # Both paths must survive the trip intact, not merely be non-empty.
+    [ -f "$script_arg" ]
+    [ -d "$root_arg" ]
+    [[ "$script_arg" == *"aahp-manifest.sh" ]]
+    # The remaining flags stay in order after the two positionals.
+    [ "$(sed -n '3p' "$TEST_TMPDIR/argv.txt")" = "--agent" ]
+    [ "$(sed -n '7p' "$TEST_TMPDIR/argv.txt")" = "--quiet" ]
+}


### PR DESCRIPTION
## The root cause is duplication, not the call site

`bin/aahp.js` had **already solved this**. Its comment reads: "On Windows, prefer Git Bash over the WSL bash shim and avoid raw `C:\...` script arguments", implemented in its own `findBashExecutable()`/`toBashScriptArg()`. `scripts/aahp-dashboard.mjs` had neither and knew nothing of them, so the same Windows defect had to be found a second time.

My first version of this PR only fixed the dashboard, which would have created a **third** copy. It now consolidates instead: one implementation in `scripts/aahp-config.mjs`, used by both call sites, merging what each side got right.

| | relative-path strategy | `/c/` MSYS form | `AAHP_BASH` override | env-driven candidates | `usr/bin` layout | per-user install |
|---|---|---|---|---|---|---|
| `bin/aahp.js` (old) | yes | yes | no | no | yes | no |
| dashboard fix (old) | no | no | yes | yes | no | yes |
| **merged** | yes | yes | yes | yes | yes | yes |

A test fails if a copy is reintroduced.

## The defect

`scripts/aahp-dashboard.mjs` shelled out to bash like this:

```js
execFileSync(
  process.env.AAHP_BASH || "bash",
  [join(scriptDir, "aahp-manifest.sh"), root, "--agent", ...],
);
```

Both halves break on Windows, independently:

1. **Path shape.** A native path is backslash-separated and bash consumes each backslash as an escape, so `C:\Users\x\s.sh` reaches the interpreter as `C:Usersxs.sh`.
2. **Interpreter.** A bare `bash` is not reliably a POSIX shell on Windows. A default Git for Windows install puts only Git's `cmd/` on PATH, which carries `git.exe` but **not** `bash.exe`, while Windows itself ships `C:\Windows\System32\bash.exe`: the WSL launcher. PATH order then selects WSL, whose filesystem has no `C:` drive, so the script cannot be opened however the path is spelled.

## Provenance, stated precisely

This was found while fixing the identical pattern in `supply-chain-guard`, which runs a **divergent local fork** of this script whose bash call has no `generate.log` guard and is therefore always reachable. That is where the failure was actually observed in the field.

To be clear about what this PR does and does not do: SCG does **not** configure `generate.log`, and does not consume the packaged dashboard in write mode, so it is **not** a consumer of this fix. Upstream, the call is reached only in write mode by a project that configures `generate.log`; `--check` exits before it. So this is a correctness fix ahead of a field report, not a response to one. I reproduced the upstream defect directly rather than inferring it from the fork.

## Reproduction

Against **unmodified 3.9.1** on Windows with a consumer-shaped config (`generate.log` set):

```
/bin/bash: C:UsersrootworkspaceAAHPscriptsaahp-manifest.sh: No such file or directory

  .ai/handoff/LOG.md was written, but MANIFEST.json regen failed:
  Run manually: aahp manifest . --quiet
```

Both defects are visible in that one line: the separators are gone **and** the interpreter is WSL's `/bin/bash`.

The consequence is worse than a failed command. `LOG.md` is written *before* the regen, so the failure leaves `MANIFEST.json` checksums stale against the file just produced, which is the state Layer 1 exists to prevent.

## Why it escaped

AAHP's own `aahp.config.json` sets only `generate.freshness` (deliberately, per ADR-004: LOG.md is an append-only agent journal, not a release journal). `writeLog()` therefore returns at the `no generate.log configured` early exit **before** reaching the bash call. No AAHP-only run, on any platform, can execute that branch.

`gates.bats` test 22 does configure `generate.log` and does reach the call site, but it passes on both Linux CI and this Windows box, because on both, `bash` happened to resolve to a real POSIX shell. Existing coverage touches the line while being blind to *which* interpreter it got.

## The fix

One implementation in `scripts/aahp-config.mjs` (the side-effect-free shared module, so it is importable without running a gate; `aahp-dashboard.mjs` has no main-guard and could not host it):

- **`resolveBash(env, platform)`** - `AAHP_BASH` wins, then on win32 an installed Git Bash by absolute path, then `"bash"` so a genuine failure stays the caller's to report. Candidates are environment-driven (`ProgramFiles`, `ProgramFiles(x86)`, `LOCALAPPDATA`) rather than hardcoded to `C:\Program Files`, so a Git install on another drive or a per-user install is still found, and Git's `usr/bin` layout is covered.
- **`toBashPath(p, platform, cwd)`** - three strategies, most robust first: a path under `cwd` becomes relative (which sidesteps the drive letter entirely and works under any bash flavour); an absolute drive path becomes the MSYS form (`C:\x` -> `/c/x`); otherwise separators are swapped. Off win32 it is a no-op, because a backslash is a legal POSIX filename character.

`cwd` is explicit because the two call sites genuinely differ: `bin/aahp.js` spawns with `cwd: process.cwd()` (the default), while the dashboard spawns with `cwd: root`. The relative strategy is wrong if computed against the other one.

`platform`, `env` and `cwd` are injectable. That is necessary rather than stylistic: it is what lets the win32 behaviour be asserted **on the ubuntu runner**, given that a Windows CI job alone would not reach the code path (see above).

## Verification

- **Reproduced** against unmodified 3.9.1 (output above), then confirmed fixed: `handoff-refresh` completes end-to-end on a consumer fixture, and `resolveBash()` now returns an absolute `C:\Program Files\Git\bin\bash.exe` instead of depending on PATH order.
- **Mutation proof.** Reverting the helpers to their pre-fix behaviour turns exactly the defect-specific tests red; restoring turns them green. The others stay green throughout, so they are not accidentally coupled.
- **`tests/bash-portability.bats`: 13 tests.** Each `toBashPath` test passes an explicit `cwd`, because `relative()`/`isAbsolute()` use the *host's* path semantics regardless of the `platform` argument - without that, which strategy runs depends on where the suite runs. 12 pass + 1 skip on Git Bash (the stand-in interpreter needs a POSIX shebang); all 13 run on Linux.
- **No CLI regression.** `bin/aahp.js` is the risky half of this change, so: `cli.bats` is **55 pass / 3 fail on this branch and 55 pass / 3 fail on unmodified `main`** - the same three documented Windows-only environment flakes (`--version`, read-only-directory permissions, `status` default path). `aahp manifest`, `aahp lint` and `aahp verify` each exit 0 on Windows through the shared resolver.
- `gates.bats` 22/22 (test 22 exercises the dashboard write path), `npm run check` (7 gates), `aahp doctor` (6 gates), `aahp lint` (7 checks), `aahp verify --level prepush` (4 layers): all green.
- The full suite is left to CI; only the affected suites were run locally.

## Follow-ups, not in this PR

- **`aahp-manifest.sh` clobbers `project` on regeneration.** `PROJECT_NAME=$(basename ...)` is unconditional, so regenerating inside a differently-named checkout (temp dir, CI dir, tarball) overwrites a consumer's real project name. `supply-chain-guard` already carries the fix and it was never upstreamed - so the estate's most-depended-upon repo is the one holding the bug. Worth doing next, and independent of everything else here. Recorded in STATUS.md.
- **No Windows CI runner.** CI is `ubuntu-latest` only, so no job executes the shipped bash tooling (`_aahp-lib.sh`, `verify-handoff.sh`, `lint-handoff.sh`) under Git Bash. That is how this survived. A `windows-latest` bats job would cover the remaining surface and is a larger change than this fix.
- **Release.** Landed under `[Unreleased]`; cutting the release is a separate decision. No current consumer is blocked: consumers pin an exact version, and the one known Windows consumer runs its own fork of this script.
- **Fork divergence.** `supply-chain-guard` carries a 405-line project-specific fork of this 197-line file, plus stale copies of `_aahp-lib.sh` and `aahp-manifest.sh`. That is being handled separately; the duplicated *primitives* (bash resolution, path conversion, CRLF normalisation, changelog grammar) are the part that has actually cost time twice, not the rendering.
