### PR TITLE
fix: fail closed on handoff impact and CI base

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,86 +2,86 @@
   "aahp_version": "3.0",
   "project": "AAHP",
   "last_session": {
-    "agent": "claude-sonnet-5",
-    "session_id": "cli-1785933588",
-    "timestamp": "2026-08-05T12:39:48Z",
-    "commit": "6548512",
-    "phase": "idle",
+    "agent": "codex",
+    "session_id": "cli-1787263831",
+    "timestamp": "2026-08-20T22:10:31Z",
+    "commit": "e865ac6",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:6be6baa329e6e06745d468ae98344e40736d000da24dd5797155a4538a7564b1",
-      "updated": "2026-08-05T12:39:41Z",
-      "lines": 213,
-      "summary": "AAHP **v3.9.2** (npm `@elvatis_com/aahp`), CHANGELOG cut and version bumped on this branch,"
+      "checksum": "sha256:6fb1c2973a1d0b4c3c191a8013a6a8e1534032606d4ecdfd7fb29eb271ce98f9",
+      "updated": "2026-08-20T22:10:19Z",
+      "lines": 81,
+      "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:e3c5d2eddd0dc82923c30070aabcbf5d22db3f24949986182b2760333cfe6eac",
-      "updated": "2026-08-05T12:39:22Z",
-      "lines": 228,
-      "summary": "Current version: **v3.9.2**"
+      "checksum": "sha256:efdc6ef8664faf9ce5120fa797b702d2353bd4c3205c62e5ba651a465326103d",
+      "updated": "2026-08-20T22:10:19Z",
+      "lines": 239,
+      "summary": "Current version: **v3.10.0**"
     },
     "LOG.md": {
       "checksum": "sha256:b6296369cedefd0c52a00e8ed2662ad839e238e8162d93c0fda76547e30c0bce",
-      "updated": "2026-08-03T16:34:00Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 250,
       "summary": "**Agent:** claude-opus-5"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:952cebfc3ba42ba60c913defd9ca292d122a4151230b53e59b9201fd0dac5933",
-      "updated": "2026-08-03T16:34:00Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 159,
       "summary": "**Agent:** Claude Opus 4.6"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:5cb8447453139052e528f8dfc67d88f3d5e74bb40e5fc1672aa55ca30980de98",
-      "updated": "2026-08-03T16:34:00Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 29,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e96e392db8dab2e9719e542dfa2a10c240d0be16ac6721298c460a22985cbdea",
-      "updated": "2026-04-05T17:29:32Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 96,
       "summary": "| Name | Path | Build | Tests | Status | Notes |"
     },
     "TRUST.md": {
       "checksum": "sha256:91f124fe10a934779ef1d7442dd54af6656bbc03c4b1cde13a9d4cac9ab248e6",
-      "updated": "2026-08-03T19:09:11Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 93,
       "summary": "| Level | Meaning |"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:1c0150404d22c6e15e39139e8b2c991b0167ba1e095f579efafb85555dfe0d88",
-      "updated": "2026-08-03T16:34:00Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 93,
       "summary": "The project motto (Asimov's Three Laws) and the **do no damage** principle live once, in README (## Our Motto: The Three Laws). Agents must never take"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:ef005f24e399791abb986b3a76403295c33ad3b28bb9b7dc777d1d0528b31151",
-      "updated": "2026-08-03T19:09:11Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 156,
       "summary": "| Agent | Model | Role | Responsibility |"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-08-03T16:33:59Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 209,
       "summary": "This register EXTENDS existing AAHP machinery; it does not fork or replace it. It"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-26T10:38:49Z",
+      "updated": "2026-08-20T21:21:47Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "Release ceremony: cut v3.9.2 (bash portability #63 + MANIFEST project-preservation #64)",
+  "quick_context": "Prepare",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 5314,
-    "full_read": 15384
+    "manifest_plus_core": 3276,
+    "full_read": 13346
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "AAHP",
   "last_session": {
     "agent": "codex",
-    "session_id": "cli-1787264470",
-    "timestamp": "2026-08-20T22:21:10Z",
-    "commit": "1d9722d",
+    "session_id": "cli-1787268540",
+    "timestamp": "2026-08-20T23:29:01Z",
+    "commit": "48aa441",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:88bc106b6fb8fe3532d83da4854053e0fcbec1ab1efdad138871a74a70e32731",
-      "updated": "2026-08-20T22:20:38Z",
-      "lines": 81,
+      "checksum": "sha256:b614efca8f080329266b88e0e29a799365f9743177eb785f14370e2f8849cdc4",
+      "updated": "2026-08-20T23:24:26Z",
+      "lines": 84,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Fix",
+  "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3288,
-    "full_read": 13358
+    "manifest_plus_core": 3427,
+    "full_read": 13497
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,16 +3,16 @@
   "project": "AAHP",
   "last_session": {
     "agent": "codex",
-    "session_id": "cli-1787263831",
-    "timestamp": "2026-08-20T22:10:31Z",
-    "commit": "e865ac6",
+    "session_id": "cli-1787264470",
+    "timestamp": "2026-08-20T22:21:10Z",
+    "commit": "1d9722d",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:6fb1c2973a1d0b4c3c191a8013a6a8e1534032606d4ecdfd7fb29eb271ce98f9",
-      "updated": "2026-08-20T22:10:19Z",
+      "checksum": "sha256:88bc106b6fb8fe3532d83da4854053e0fcbec1ab1efdad138871a74a70e32731",
+      "updated": "2026-08-20T22:20:38Z",
       "lines": 81,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
@@ -77,11 +77,11 @@
       "summary": "{"
     }
   },
-  "quick_context": "Prepare",
+  "quick_context": "Fix",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3276,
-    "full_read": 13346
+    "manifest_plus_core": 3288,
+    "full_read": 13358
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,17 +3,17 @@
   "project": "AAHP",
   "last_session": {
     "agent": "codex",
-    "session_id": "cli-1787268540",
-    "timestamp": "2026-08-20T23:29:01Z",
-    "commit": "48aa441",
+    "session_id": "cli-1787268998",
+    "timestamp": "2026-08-20T23:36:39Z",
+    "commit": "c332a23",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:b614efca8f080329266b88e0e29a799365f9743177eb785f14370e2f8849cdc4",
-      "updated": "2026-08-20T23:24:26Z",
-      "lines": 84,
+      "checksum": "sha256:218922e1a3daea578a2d46c65f1b17e22b3b34b25a8c5a5409f61d462020e822",
+      "updated": "2026-08-20T23:36:27Z",
+      "lines": 85,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3427,
-    "full_read": 13497
+    "manifest_plus_core": 3460,
+    "full_read": 13530
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -7,7 +7,7 @@
 > `- [ ]` while unresolved, `- [x]` only on evidence; before a task is `done` every
 > criterion is checked, waived `(waived: rationale)`, or moved `(follow-up: ref)`.
 
-Current version: **v3.9.2**
+Current version: **v3.10.0**
 
 ---
 
@@ -24,6 +24,17 @@ Counts mirror the `tasks` registry in `MANIFEST.json`.
 ---
 
 ## Recently Completed
+
+### 2026-08-20: v3.10.0 prepared - fail-closed CI base + reviewed M-only impact
+
+- Added explicit `--base SHA` / `AAHP_BASE_SHA` anchoring. CI rejects missing, zero,
+  invalid, unreadable, HEAD-equal, and undiffable bases.
+- Added exact regular tracked-file `handoffImpact.nonImpactingModifiedFiles` entries with
+  required reasons. Only `M` can be non-impacting; A/D/R/C and mixed source changes
+  remain impacting.
+- Removed the actor-wide dependency-bot workflow bypass, so Layer 1 always runs.
+- Added focused mutation, schema, workflow, CLI, and propagation coverage.
+- Prepared version 3.10.0 without tagging, publishing, or merging it.
 
 ### 2026-08-05: v3.9.2 - Windows bash portability + MANIFEST project-name preservation (#63, #64)
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,6 +1,6 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-08-20 by codex
+> Last updated: 2026-08-21 by codex
 > Commit: (review branch, pending commit)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
@@ -16,13 +16,14 @@ been tagged, published, or merged. The release changes Layer 2 in two bounded wa
   pushes pass the event `before` SHA, and manual runs require an input. Missing, zero,
   invalid, unreadable, HEAD-equal, and undiffable bases fail closed.
 - An optional `handoffImpact.nonImpactingModifiedFiles` list can classify one exact
-  regular tracked-file modification (`M`) as non-impacting when it carries a non-empty review
-  reason. A/D/R/C, mixed source changes, config changes, and handoff changes remain
-  impacting. The runtime parser rejects unsafe or ambiguous configuration even without
-  a separate schema command.
+  content-only regular tracked-file modification (`M`) as non-impacting when the old and
+  new Git modes match and it carries a visible review reason. A/D/R/C, mode changes,
+  mixed source changes, config changes, and handoff changes remain impacting. The
+  Node/Python runtime parser and schema reject unsafe, invisible, or ambiguous policy.
 
 The actor-wide dependency-bot workflow bypass is removed. Layer 1 now runs for every
-actor. The gate remains verify-only and never regenerates handoff state.
+actor. The package now includes the workflow that `propagate.sh` installs. The gate
+remains verify-only and never regenerates handoff state.
 <!-- /SECTION: summary -->
 
 ---
@@ -33,11 +34,12 @@ actor. The gate remains verify-only and never regenerates handoff state.
 | Check | Result | Notes |
 |-------|--------|-------|
 | npm version | READY | package, lockfile, changelog, CLI help, and handoff surfaces set to 3.10.0 |
-| `tests/handoff-impact.bats` | FOCUSED PASS | parser mutations, M-only classification, A/D/R/C, mixed change, base failures, forced diff failure, workflow, CLI, schema |
-| `tests/propagate.bats` | FOCUSED PASS | parser and explicit-base workflow propagate together |
+| `tests/handoff-impact.bats` | FOCUSED PASS | 24 pass + 3 Windows skips; empty base, staged/CI endpoint modes, parser parity, M-only, A/D/R/C, mixed and diff failures pass; schema passed separately; symlink case awaits Linux CI |
+| `tests/propagate.bats` | FOCUSED PASS | 2/2; source checkout and installed npm tarball propagate byte-identical gate, parser, and workflow |
 | `tests/verify.bats` | FOCUSED PASS | 22/22 under Git Bash with explicit CI bases |
 | schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
 | shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
+| `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, and handoff freshness |
 | shellcheck | FIXED, CI RERUN PENDING | first Linux run caught SC2015/SC2016 in the new parser; idiom corrected and intentional JS quoting scoped |
 | full Bats suite | CI | deliberately not run on Windows; Linux CI is authoritative |
 <!-- /SECTION: build_health -->
@@ -51,12 +53,12 @@ actor. The gate remains verify-only and never regenerates handoff state.
 |-----------|------|-------|-------|
 | Verify gate | `scripts/verify-handoff.sh` | Changed | explicit base, fail-closed diff, name-status classifier |
 | Shared library | `scripts/_aahp-lib.sh` | Changed | Node/Python runtime parser for reviewed impact config |
-| Required workflow | `.github/workflows/aahp-verify.yml` | Changed | no actor bypass; explicit base; read-only token; immutable action pins |
+| Required workflow | `.github/workflows/aahp-verify.yml` | Changed | no actor bypass; explicit base; read-only token; immutable action pins; evaluator-path trust boundary documented |
 | Config schema/example | `schema/aahp-config.schema.json`, `aahp.config.example.json` | Changed | additive `handoffImpact` contract |
 | CLI | `bin/aahp.js` | Changed | verify help documents `--base SHA` |
 | Specification | `README.md` | Changed | Section 2.8 and ADR-018 define the contract |
 | Rollout | `scripts/ROLLOUT.md` | Changed | consumer propagation and mutation checks documented |
-| Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, not released |
+| Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, workflow included in npm artifact, not released |
 <!-- /SECTION: components -->
 
 ---
@@ -68,6 +70,7 @@ actor. The gate remains verify-only and never regenerates handoff state.
 |-----|----------|-------------|
 | Linux CI evidence | HIGH | Required before merge; the full suite and shellcheck belong on the hosted Linux runner. |
 | Release | NORMAL | Do not tag or publish until review is merged and the release ceremony is explicitly authorized. |
+| Evaluator path protection | HIGH | The supplied `pull_request` workflow executes proposed workflow and gate code. A consumer must require trusted review for evaluator paths or supply a default-branch evaluator; v3.10.0 cannot configure repository rules. |
 | Delete-both-sides Layer 1 hole | MEDIUM | Pre-existing: removing a canonical handoff file and its index entry still needs a required-set protocol decision. |
 | Windows CI runner | MEDIUM | Pre-existing: Git Bash behavior is locally focused-tested, but CI remains Linux-only. |
 <!-- /SECTION: what_is_missing -->
@@ -77,5 +80,5 @@ actor. The gate remains verify-only and never regenerates handoff state.
 ## Next Actions
 
 1. Regenerate `MANIFEST.json` and run the focused repository gates.
-2. Open the review pull request and let hosted Linux CI run the full suite and shellcheck.
+2. Push the review pull request replacement head and let hosted Linux CI run the full suite and shellcheck.
 3. Do not tag, publish, or merge from this session.

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -38,7 +38,7 @@ actor. The gate remains verify-only and never regenerates handoff state.
 | `tests/verify.bats` | FOCUSED PASS | 22/22 under Git Bash with explicit CI bases |
 | schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
 | shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
-| shellcheck | CI | not installed on this Windows host; Linux CI is authoritative |
+| shellcheck | FIXED, CI RERUN PENDING | first Linux run caught SC2015/SC2016 in the new parser; idiom corrected and intentional JS quoting scoped |
 | full Bats suite | CI | deliberately not run on Windows; Linux CI is authoritative |
 <!-- /SECTION: build_health -->
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -40,7 +40,8 @@ remains verify-only and never regenerates handoff state.
 | schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
 | shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
 | `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, and handoff freshness |
-| shellcheck | FIXED, CI RERUN PENDING | first Linux run caught SC2015/SC2016 in the new parser; idiom corrected and intentional JS quoting scoped |
+| shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |
+| hosted Linux suite | REPLACEMENT REQUIRED | `c332a23` passed 361/362; the CI mode fixture let `git add` restore mode 100644 on Linux, so it now reasserts 100755 before its content-plus-mode commit |
 | full Bats suite | CI | deliberately not run on Windows; Linux CI is authoritative |
 <!-- /SECTION: build_health -->
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,7 +1,7 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-08-05 by claude-sonnet-5
-> Commit: (pending merge to main)
+> Last updated: 2026-08-20 by codex
+> Commit: (review branch, pending commit)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
 > It reflects the *current* reality, not history. History lives in LOG.md.
@@ -9,40 +9,20 @@
 ---
 
 <!-- SECTION: summary -->
-AAHP **v3.9.2** (npm `@elvatis_com/aahp`), CHANGELOG cut and version bumped on this branch,
-release tag pending merge to main. File-based AI-to-AI handoff protocol plus CLI for init,
-lint, migrate, verify, check, doctor, status, archive, criteria, and manifest regeneration.
+AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not
+been tagged, published, or merged. The release changes Layer 2 in two bounded ways:
 
-Shipped surface (high level):
-- **Integrity:** `aahp verify` (4 layers), `aahp lint` (7 checks including conflict-marker
-  refuse), MANIFEST checksums, LOG archive integrity index
-- **Governance:** config-driven gates via `aahp check`, `aahp doctor` conformance record,
-  CONSTITUTION.md, portable `init --gates`
-- **Lifecycle:** acceptance-criteria advisory report (`aahp criteria`), Grounded Reflection
-  Layer (TRUST provenance + GROUNDING.md), optional Phase 4.5 in WORKFLOW
-- **Ops:** `aahp status`, `aahp archive`, OIDC npm publish on semver tags, badge workflows
+- CI diffs are anchored to an explicit base commit. Pull requests pass their base SHA,
+  pushes pass the event `before` SHA, and manual runs require an input. Missing, zero,
+  invalid, unreadable, HEAD-equal, and undiffable bases fail closed.
+- An optional `handoffImpact.nonImpactingModifiedFiles` list can classify one exact
+  regular tracked-file modification (`M`) as non-impacting when it carries a non-empty review
+  reason. A/D/R/C, mixed source changes, config changes, and handoff changes remain
+  impacting. The runtime parser rejects unsafe or ambiguous configuration even without
+  a separate schema command.
 
-This session (2026-08-05) is an AAHP-vs-supply-chain-guard (SCG) divergence audit and two
-independent bug fixes, both now merged to `main` per Emre's "no divergence within my
-projects" instruction:
-
-- **PR #63:** fixed a Windows-only defect in `handoff-refresh`. `aahp-dashboard.mjs`
-  shelled out to a bare `bash` with native backslash paths, which fails on Windows two
-  independent ways: bash eats the backslashes as escapes, and a bare `bash` can resolve to
-  the WSL launcher, which has no `C:` drive. Root cause was a second implementation -
-  `bin/aahp.js` already solved this with its own `findBashExecutable()`/`toBashScriptArg()`,
-  and the dashboard call site had neither. There is now ONE implementation,
-  `resolveBash()`/`toBashPath()` in `aahp-config.mjs`, used by both, with a test that fails
-  if a copy reappears. Found while fixing the identical pattern in supply-chain-guard's
-  divergent fork, then reproduced and fixed upstream directly (not a field report).
-- **PR #64:** fixed `aahp-manifest.sh` unconditionally overwriting MANIFEST `project` with
-  the directory basename on every regeneration, clobbering a consumer's real project name
-  whenever regenerated inside a differently-named checkout. Full detail in the audit section
-  below.
-
-Both fixes were found independently while investigating the same underlying problem (AAHP
-vs. SCG divergence); #63's own "What is Missing" already flagged the `project`-clobber bug
-by name and deliberately left it for a separate PR, which is what #64 became.
+The actor-wide dependency-bot workflow bypass is removed. Layer 1 now runs for every
+actor. The gate remains verify-only and never regenerates handoff state.
 <!-- /SECTION: summary -->
 
 ---
@@ -52,17 +32,14 @@ by name and deliberately left it for a separate PR, which is what #64 became.
 
 | Check | Result | Notes |
 |-------|--------|-------|
-| npm version | OK | 3.9.2 cut on this branch (CHANGELOG + package.json); tag/publish pending merge |
-| `bash-portability.bats` | OK (#63) | 13 tests, new; 12 pass + 1 skip on Git Bash (stand-in interpreter needs a POSIX shebang); CI green |
-| `tests/manifest.bats` (#64) | OK | 21/21 local, incl. 2 new project-preservation tests; CI green |
-| Real-consumer verification (#64) | OK | Fixed script run against a copy of SCG's actual `.ai/handoff/` from a differently-named directory; preserved `"project": "supply-chain-guard"` |
-| `check-changelog-format.mjs` / `check-forbidden-patterns.mjs` | OK | ran locally for #64 |
-| `aahp doctor` | OK (pre-existing) | handoff-set fails on partial index (aligned with verify Layer 1 / lint) |
-| `doctor.bats` / `lint.bats` / `verify.bats` / `gates.bats` / `acceptance-criteria.bats` | OK (CI, pre-existing) | untouched by #63/#64; CI is authoritative |
-| `cli.bats` | PARTIAL local | known Windows-only flakes; green on Linux CI |
-| `npm run check` | OK | 8 config-driven gates |
-| shellcheck | CI | not installed offline on this Windows host; CI covers shipped scripts, incl. both branches' changes |
-| Full bats suite | CI | do not run full suite on this Windows host (~hours); push and let GHA decide |
+| npm version | READY | package, lockfile, changelog, CLI help, and handoff surfaces set to 3.10.0 |
+| `tests/handoff-impact.bats` | FOCUSED PASS | parser mutations, M-only classification, A/D/R/C, mixed change, base failures, forced diff failure, workflow, CLI, schema |
+| `tests/propagate.bats` | FOCUSED PASS | parser and explicit-base workflow propagate together |
+| `tests/verify.bats` | FOCUSED PASS | 22/22 under Git Bash with explicit CI bases |
+| schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
+| shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
+| shellcheck | CI | not installed on this Windows host; Linux CI is authoritative |
+| full Bats suite | CI | deliberately not run on Windows; Linux CI is authoritative |
 <!-- /SECTION: build_health -->
 
 ---
@@ -72,22 +49,14 @@ by name and deliberately left it for a separate PR, which is what #64 became.
 
 | Component | Path | State | Notes |
 |-----------|------|-------|-------|
-| CLI | `bin/aahp.js` | Complete | init, manifest, lint, migrate, verify, check, doctor, status, archive, criteria, migrate-grounding |
-| Shared lib | `scripts/_aahp-lib.sh` | Complete | checksum, trust TTL, auto_summary (scans past header chrome) |
-| Verify gate | `scripts/verify-handoff.sh` | Complete | 4 layers; Layer 1 catches missing + partial index |
-| Lint | `scripts/lint-handoff.sh` | Complete | 7 checks; check 7 = conflict markers |
-| Conflict markers | `scripts/check-conflict-markers.mjs` | Complete | CRLF-safe; bash/grep fallback |
-| Doctor | `bin/aahp.js` cmdDoctor | Complete | handoff-set matches Layer 1 partial-index rule |
-| Release gates | `scripts/check-*.mjs` | Complete | version-sync, changelog, claims, forbidden-patterns, schema-doc-sync, doc-links |
-| Dashboard check | `scripts/aahp-dashboard.mjs` | Complete | handoff freshness; bash call goes through `resolveBash`/`toBashPath` |
-| Shared config lib | `scripts/aahp-config.mjs` | Complete | root/pkg/config resolution, git enumeration, bash interpreter + path portability |
-| Manifest gen | `scripts/aahp-manifest.sh` | Complete | preserves tasks / next_task_id / cross_repo_ref / project |
-| Archive | archive command | Complete | keep 10 newest LOG entries |
-| Schemas | `schema/` | Complete | manifest, config, pii-allowlist |
-| Templates | `templates/` | Complete | 12 files incl GROUNDING.md |
-| CI | `.github/workflows/` | Complete | ci, verify, lint, manifest, archive, pii, CodeQL; Actions active |
-| Hooks | `scripts/hooks/` + install-hooks.sh | Complete | pre-commit / pre-push |
-| Rollout | `scripts/ROLLOUT.md` | Complete | project-agnostic wave playbook |
+| Verify gate | `scripts/verify-handoff.sh` | Changed | explicit base, fail-closed diff, name-status classifier |
+| Shared library | `scripts/_aahp-lib.sh` | Changed | Node/Python runtime parser for reviewed impact config |
+| Required workflow | `.github/workflows/aahp-verify.yml` | Changed | no actor bypass; explicit base; read-only token; immutable action pins |
+| Config schema/example | `schema/aahp-config.schema.json`, `aahp.config.example.json` | Changed | additive `handoffImpact` contract |
+| CLI | `bin/aahp.js` | Changed | verify help documents `--base SHA` |
+| Specification | `README.md` | Changed | Section 2.8 and ADR-018 define the contract |
+| Rollout | `scripts/ROLLOUT.md` | Changed | consumer propagation and mutation checks documented |
+| Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, not released |
 <!-- /SECTION: components -->
 
 ---
@@ -97,117 +66,16 @@ by name and deliberately left it for a separate PR, which is what #64 became.
 
 | Gap | Severity | Description |
 |-----|----------|-------------|
-| Delete-both-sides Layer 1 hole | MEDIUM | Removing a canonical handoff file **and** its `files` entry still passes Layer 1 (no required-set assertion). Fix needs a protocol decision on the minimal required set (STATUS + MANIFEST candidates). |
-| Template/dogfood DASHBOARD staleness | LOW | DASHBOARD.md still shows early v2 task rows; selection authority is MANIFEST `tasks` (see WORKFLOW). Cosmetic. |
-| Long LOG entry bodies | LOW | LOG.md is at the 10-entry cap with long bodies (~250 lines). Protocol entry count is satisfied; optional future trim of body length only. |
-| Windows full-suite speed | LOW | Full bats is hours on this host; Linux CI / openclaw is the full-suite authority. |
-| No Windows CI runner | MEDIUM | CI is `ubuntu-latest` only, so no job executes the shipped bash tooling under Git Bash. This is how the `handoff-refresh` interpreter defect (fixed in #63) reached a consumer. Mitigated but not closed: `resolveBash`/`toBashPath` take `platform`/`env` as parameters, so their win32 behaviour is asserted on the Linux runner. A `windows-latest` bats job would cover the remaining surface (`_aahp-lib.sh`, `verify-handoff.sh`, `lint-handoff.sh`), and is a larger change than either #63 or #64. |
-| Consumer-only code paths untested | MEDIUM | AAHP configures only `generate.freshness`, so `writeLog()` returns before the bash call and AAHP's own dogfooding never executes it. Any AAHP-only gate run, on any platform, is blind to that branch. Coverage has to come from a consumer-shaped fixture. |
-| AAHP/SCG shared-primitive duplication | MEDIUM | `_aahp-lib.sh` and `aahp-manifest.sh` are hand-copied into `homeofe/supply-chain-guard` because SCG's fork `aahp-dashboard.mjs` calls the local copies. See "AAHP vs supply-chain-guard divergence audit" below. Decision needed from Emre before Step 3 (SCG-side) can land. |
+| Linux CI evidence | HIGH | Required before merge; the full suite and shellcheck belong on the hosted Linux runner. |
+| Release | NORMAL | Do not tag or publish until review is merged and the release ceremony is explicitly authorized. |
+| Delete-both-sides Layer 1 hole | MEDIUM | Pre-existing: removing a canonical handoff file and its index entry still needs a required-set protocol decision. |
+| Windows CI runner | MEDIUM | Pre-existing: Git Bash behavior is locally focused-tested, but CI remains Linux-only. |
 <!-- /SECTION: what_is_missing -->
 
 ---
 
-## AAHP vs supply-chain-guard divergence audit (2026-08-05)
+## Next Actions
 
-Emre asked to eliminate divergence between AAHP and its consumer `homeofe/supply-chain-guard`
-(SCG, v5.25.4, pins `@elvatis_com/aahp` at exact 3.9.1). Audited by execution (diffs, greps,
-functional tests, live gate runs), not by reading claims. Full per-claim evidence lives in
-this session's transcript; summary below.
-
-**Confirmed:** SCG shadows exactly three AAHP-published files (`_aahp-lib.sh`,
-`aahp-manifest.sh`, `aahp-dashboard.mjs`) because SCG's fork dashboard calls the local
-`aahp-manifest.sh`, which sources the local `_aahp-lib.sh`. `propagate.sh` (AAHP's
-anti-divergence mechanism) copies the first two but not the third by design.
-`aahp-dashboard.mjs` is architecturally a different program in each repo (AAHP: generic,
-config-driven, arbitrary consumer root via `resolveRoot()`; SCG: hardcoded to itself,
-generates DASHBOARD.md/TRUST.md/LOG.md from `src/`, `tsconfig.json`, a dependency table).
-`scripts/` is published with no `package.json` `exports` map, so a consumer can deep-import
-`@elvatis_com/aahp/scripts/*.mjs` today with zero AAHP change; adding an `exports` map later
-is a breaking-shaped change (allowlists every unlisted deep import).
-
-**Fixed this session (Step 1):** `aahp-manifest.sh` unconditionally overwrote MANIFEST
-`project` with the directory basename on every regeneration - confirmed by a functional
-test (not just a code read), including against a real copy of SCG's own `.ai/handoff/`.
-Fixed to preserve the existing value except on first-ever generation. Also fixed a latent
-bug this uncovered in the *same* preservation mechanism added in 3.9.1: the tasks/
-`next_task_id`/`cross_repo_ref` fields were tab-joined and split with `IFS=$'\t' read`, but
-tab is IFS whitespace, so bash silently strips/collapses leading empty fields whenever an
-earlier field is empty and a later one isn't (e.g. no tasks but a `cross_repo_ref` present).
-Switched the delimiter to `\x1f` (Unit Separator). Bats coverage added; merged to main as #64.
-
-**Corrections to the pre-session brief (verify before trusting a summary of this audit -
-these were wrong or overstated in the original working notes, don't re-propagate them):**
-- SCG's `aahp.config.json` `check.skip: ["handoff"]` does **not** disable the real 4-layer
-  handoff gate. It only skips one narrow sub-check inside `aahp check`. The actual gate
-  (`aahp verify . --level ci`) runs unconditionally in SCG's `aahp-verify.yml`, no escape
-  hatch. SCG's handoff protocol enforcement is intact.
-- SCG's TRUST records are **not** stale/expired. All 5 rows are within TTL as of
-  2026-08-05 (2 of them expire *today* and need refreshing by 2026-08-06, but that is a
-  same-day risk, not an active false-pass).
-- No gate named or shaped like "schema-doc-sync" enforces "new `aahp.config.json` key needs
-  a schema + README update." `check-schema-doc-sync.mjs` is an unrelated generic value-set
-  comparator. `additionalProperties: false` is real in the schema but is only exercised by
-  one bats test on `aahp init --gates` output, not on hand-edited configs.
-- SCG's CHANGELOG-heading and NEXT_ACTIONS-freshness regexes in SCG's fork dashboard **do**
-  silently drop SemVer prerelease/build-metadata versions (confirmed, both instances) - this
-  is a real latent bug in SCG's fork, not currently observable (no prerelease headings exist
-  yet), out of scope for this AAHP session, worth a note in SCG's own backlog.
-
-## Decisions from Emre
-
-1. **Step 2 - primitive-sharing mechanism: resolved.** Emre approved merging #63 and #64
-   and cutting a release, 2026-08-05. Both merged to `main`. Recommendation carried forward:
-   SCG deep-imports `resolveBash`/`toBashPath` (and similar shared primitives) from
-   `@elvatis_com/aahp/scripts/aahp-config.mjs` - this works today with zero further AAHP
-   change. A declared `exports` map is cleaner but is a breaking-shaped change (allowlists
-   every unlisted deep import) and was not added.
-2. **Step 4 - generalize SCG's generators into AAHP?: still open.** Emre pushed back on the
-   "logic only, stop at Step 3" recommendation, asking for the actual argument against fully
-   upstreaming rather than a restatement of "it's a lot of work." Answered in-session:
-   (a) after Step 3 there is no *shared* logic left to diverge - the two vendored bash files
-   are deleted outright, and what remains in SCG imports AAHP rather than duplicating it,
-   structurally the same as any consumer importing a library and writing its own code on
-   top; (b) AAHP's own CLAUDE.md commits it to being stack-agnostic (Node + bash + standard
-   tools only), while SCG's generator is Node/TypeScript-shaped (`tsconfig.json`, `src/`
-   layout, a `commander` pin) - absorbing it means redesigning it as config-driven, not
-   moving code, which is the actual multi-session cost; (c) blast radius is asymmetric - a
-   bug in SCG's generator today (two were found this session, see corrections above) affects
-   only SCG, but the same bug upstreamed ships to every AAHP consumer; (d) renaming/moving
-   the generator changes its AUTO-GENERATED banner, which changes DASHBOARD/TRUST/LOG
-   content, which changes MANIFEST checksums - not additive, a breaking change needing its
-   own migration. A middle path (AAHP owns a plugin mechanism, consumers register their own
-   sections) was floated as worth scoping separately rather than deciding by default. Emre
-   has not yet picked an option pending this answer - revisit before starting Step 4.
-3. **Step 3 - SCG-side changes** (bump pin, delete SCG's duplicated primitives, pull
-   `aahp_manifest_index()` down, delete the two stale bash copies, rename
-   `aahp-dashboard.mjs`) can now start: the release exists to pin to. Not started this
-   session - next incoming agent or session should pick this up in supply-chain-guard.
-
----
-
-## Recently Resolved (this session)
-
-| Item | Resolution |
-|------|------------|
-| `handoff-refresh` MANIFEST regen fails on Windows (#63) | `resolveBash()` prefers an installed Git Bash over a bare PATH lookup; `toBashPath()` normalises separators. `AAHP_BASH` still overrides both. |
-| Windows behaviour untestable on Linux CI (#63) | Helpers take `platform`/`env` as parameters, so `tests/bash-portability.bats` asserts the win32 paths deterministically on `ubuntu-latest`. |
-| AAHP/SCG divergence audit | Verified by execution; several pre-session claims corrected (see section above) |
-| MANIFEST `project` clobber bug (#64) | Fixed; preserves existing value except on first-ever generation |
-| Latent tab/IFS field-misalignment bug (#64) | Found while fixing the above (same code block, added in 3.9.1); fixed by switching the field delimiter to `\x1f` |
-
-Prior sessions' resolved items (#55-#61, 2026-08-03 handoff hygiene sweep) are in LOG.md
-and CHANGELOG.md; not repeated here per this file's own "current reality, not history" rule.
-
----
-
-## Trust Levels
-
-- **(Verified):** #63's defect reproduces on Windows with unmodified 3.9.1 against a consumer-shaped config (`generate.log` set); mutation proof on `tests/bash-portability.bats` (revert turns the two defect-specific tests red).
-- **(Verified):** #64's MANIFEST `project`-preservation fix, by functional test plus a real-consumer run against a copy of SCG's actual `.ai/handoff/`.
-- **(Verified):** `gates.bats` 22/22, `npm run check`, and `tests/manifest.bats` 21/21 green locally; both PRs' CI (10 checks each) green before merge.
-- **(Assumed):** full suite green on Linux CI after push (not re-run locally end-to-end on Windows; shellcheck unavailable on this host).
-- **(Known gap):** no Windows CI runner, and AAHP's own config cannot reach the `writeLog()` bash-call path (see What is Missing).
-- **(Known gap):** delete-both-sides Layer 1 hole remains (see What is Missing).
-- **(Known gap):** AAHP/SCG shared-primitive duplication remains until Emre decides Step 2/4
-  (see "Decisions needed from Emre" above).
+1. Regenerate `MANIFEST.json` and run the focused repository gates.
+2. Open the review pull request and let hosted Linux CI run the full suite and shellcheck.
+3. Do not tag, publish, or merge from this session.

--- a/.github/workflows/aahp-verify.yml
+++ b/.github/workflows/aahp-verify.yml
@@ -1,8 +1,8 @@
 # AAHP Verify - the intended REQUIRED status check for the handoff gate.
 #
 # Runs `aahp verify --level ci`, which executes all 4 layers with NO escape
-# hatch (AAHP_SKIP_VERIFY is ignored at --level ci). This is the off-machine,
-# non-bypassable backstop behind the local pre-commit / pre-push hooks:
+# hatch (AAHP_SKIP_VERIFY is ignored at --level ci). This is the off-machine
+# backstop behind the local pre-commit / pre-push hooks:
 #   Layer 1: MANIFEST checksum integrity
 #   Layer 2: content-drift gate (code changed => STATUS.md + MANIFEST.json must change)
 #   Layer 3: commit-pointer freshness
@@ -12,8 +12,10 @@
 # event's explicit base commit so pull requests compare against their base and
 # pushes compare against the pre-push commit instead of HEAD against itself.
 #
-# Mark this job as a REQUIRED status check in branch protection so the gate
-# cannot be bypassed by skipping local hooks.
+# Mark this job as a REQUIRED status check, and require trusted review for
+# changes to this workflow and the gate/parser it executes. A pull_request
+# workflow runs the proposed branch, so the status alone is self-authorizing
+# unless repository rules protect those evaluator paths.
 
 name: AAHP Verify
 

--- a/.github/workflows/aahp-verify.yml
+++ b/.github/workflows/aahp-verify.yml
@@ -8,18 +8,17 @@
 #   Layer 3: commit-pointer freshness
 #   Layer 4: TRUST-TTL expiry (advisory)
 #
-# Dependabot exemption: a pure dependency bump introduces no handoff-state change,
-# so the AAHP handoff gate does not apply to it. The job stays a REQUIRED check but
-# no-ops to success when the change originates from dependabot[bot] - on both the PR
-# (github.actor) and the resulting push to main (head_commit.author). Security and
-# build remain gated by the supply-chain-guard and CodeQL checks, which still run.
+# The workflow always runs Layer 1, regardless of actor. Layer 2 receives the
+# event's explicit base commit so pull requests compare against their base and
+# pushes compare against the pre-push commit instead of HEAD against itself.
 #
-# NOTE: GitHub Actions is currently OFF org-wide (cost sweep). This workflow is
-# committed anyway so it activates automatically when Actions is re-enabled.
-# Once Actions is on, mark this job as a REQUIRED status check in branch
-# protection so the gate cannot be bypassed by skipping local hooks.
+# Mark this job as a REQUIRED status check in branch protection so the gate
+# cannot be bypassed by skipping local hooks.
 
 name: AAHP Verify
+
+permissions:
+  contents: read
 
 on:
   push:
@@ -27,42 +26,38 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      base:
+        description: Exact base commit SHA for the Layer 2 diff
+        required: true
+        type: string
 
 jobs:
   aahp-verify:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Dependabot exemption (handoff gate not applicable)
-        if: ${{ github.actor == 'dependabot[bot]' || github.event.head_commit.author.username == 'dependabot[bot]' }}
-        run: |
-          echo "Dependabot change detected: the AAHP handoff gate does not apply."
-          echo "A pure dependency bump introduces no handoff-state change."
-          echo "Security and build remain gated by the supply-chain-guard and CodeQL checks."
-
       - name: Checkout code
-        if: ${{ github.actor != 'dependabot[bot]' && github.event.head_commit.author.username != 'dependabot[bot]' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so the content-drift gate can diff against the base.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Node.js
-        if: ${{ github.actor != 'dependabot[bot]' && github.event.head_commit.author.username != 'dependabot[bot]' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 
       - name: Set up Python 3
-        if: ${{ github.actor != 'dependabot[bot]' && github.event.head_commit.author.username != 'dependabot[bot]' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.x'
 
       - name: Run aahp verify (CI level, no escape hatch)
-        if: ${{ github.actor != 'dependabot[bot]' && github.event.head_commit.author.username != 'dependabot[bot]' }}
         run: bash scripts/verify-handoff.sh . --level ci
+        env:
+          AAHP_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || inputs.base }}
 
       - name: Run aahp doctor (conformance record)
-        if: ${{ github.actor != 'dependabot[bot]' && github.event.head_commit.author.username != 'dependabot[bot]' }}
         run: node bin/aahp.js doctor . --json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ independently of the npm version).
 ### Added
 - `handoffImpact.nonImpactingModifiedFiles` provides an optional, reviewed Layer 2
   classification for maintenance-only files. Each entry requires one exact
-  repo-relative regular tracked `file` and a non-empty `reason`. Only a content modification
-  (`M`) can be non-impacting; additions, deletions, renames, copies, type changes, and
+  repo-relative regular tracked `file` and a reviewable `reason` containing a visible
+  letter or number. Only a content-only modification (`M`) whose old and new regular-file
+  modes match can be non-impacting; additions, deletions, renames, copies, type changes, and
   mixed source changes remain impacting. Every applied classification logs the file and
   reason.
 - `aahp verify --base SHA` and its `AAHP_BASE_SHA` environment equivalent anchor the
@@ -34,18 +35,27 @@ independently of the npm version).
 - The required workflow no longer bypasses verification for an actor. Layer 1 now runs
   for every change, including automated dependency updates.
 - The optional impact parser fails closed without relying on an external schema command:
-  malformed JSON and types, empty reasons, absolute or traversal paths, globs and
+  malformed JSON and types, non-standard numeric constants, empty or invisible reasons,
+  control or format characters, absolute or traversal paths, globs and
   metacharacters, directories, untracked paths, symlinks, gitlinks, handoff paths,
   the config itself, duplicate JSON keys, duplicate entries, and prefix-like ambiguity
-  are rejected. Untracked or unstaged working-tree policy cannot authorize an index
-  change.
+  are rejected. The policy file itself must be a regular tracked Git object; a symlink
+  cannot delegate policy to a mutable referent. Untracked or unstaged working-tree policy
+  cannot authorize an index change, and mode-only or content-plus-mode changes cannot use
+  the content-only exception.
 
 ### Changed
 - The config schema, example, specification, architectural decision log, and rollout
   guidance now define the exact-file M-only contract and explicit CI base requirement.
 - The required workflow declares read-only contents permission, disables persisted
   checkout credentials, and pins every third-party action to an immutable commit.
+- Documentation now states the pull-request trust boundary explicitly: requiring the
+  status is not sufficient unless repository rules also require trusted review for the
+  workflow and the gate/parser paths it executes.
 - Propagation coverage proves the workflow and shared parser travel together.
+- The npm artifact now includes the canonical verify workflow consumed by
+  `scripts/propagate.sh`; packed-artifact coverage installs the tarball and proves the
+  propagated gate, parser, and workflow are byte-identical to the release sources.
 
 ## [3.9.2] - 2026-08-05
 **Windows bash portability, one resolver; MANIFEST project-name preservation**
@@ -366,7 +376,8 @@ independently of the npm version).
 ### Changed
 - Git hooks are de-vendored: they resolve `scripts/verify-handoff.sh` when it is vendored,
   else the installed `aahp` CLI via `npx --no-install`, and skip when neither resolves. The
-  required CI check remains the non-bypassable authority.
+  required CI check remains the off-machine authority (the evaluator-path trust boundary
+  is clarified in 3.10.0).
 - The enumerating governance gates (`check-forbidden-patterns.mjs`, `check-doc-links.mjs`)
   fail loud outside a git work tree instead of silently scanning zero files: file
   enumeration goes through a shared `git ls-files` helper that throws when the project root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ independently of the npm version).
 
 ## [Unreleased]
 
+## [3.10.0] - 2026-08-20
+**Fail-closed Layer 2 base selection and reviewed exact-file impact classification**
+
+### Added
+- `handoffImpact.nonImpactingModifiedFiles` provides an optional, reviewed Layer 2
+  classification for maintenance-only files. Each entry requires one exact
+  repo-relative regular tracked `file` and a non-empty `reason`. Only a content modification
+  (`M`) can be non-impacting; additions, deletions, renames, copies, type changes, and
+  mixed source changes remain impacting. Every applied classification logs the file and
+  reason.
+- `aahp verify --base SHA` and its `AAHP_BASE_SHA` environment equivalent anchor the
+  Layer 2 diff explicitly. The required workflow passes the pull request base SHA for a
+  pull request, the event `before` SHA for a push, and a required input for a manual run.
+
+### Fixed
+- `--level ci` no longer guesses a base or permits a vacuous HEAD-versus-HEAD diff.
+  Missing, all-zero, malformed, unreadable, HEAD-equal bases and any git diff failure
+  are blocking findings rather than empty change sets that can report green. The gate
+  compares base and HEAD endpoint trees so a rollback or force-push cannot collapse to
+  an empty merge-base-to-HEAD diff.
+- The required workflow no longer bypasses verification for an actor. Layer 1 now runs
+  for every change, including automated dependency updates.
+- The optional impact parser fails closed without relying on an external schema command:
+  malformed JSON and types, empty reasons, absolute or traversal paths, globs and
+  metacharacters, directories, untracked paths, symlinks, gitlinks, handoff paths,
+  the config itself, duplicate JSON keys, duplicate entries, and prefix-like ambiguity
+  are rejected. Untracked or unstaged working-tree policy cannot authorize an index
+  change.
+
+### Changed
+- The config schema, example, specification, architectural decision log, and rollout
+  guidance now define the exact-file M-only contract and explicit CI base requirement.
+- The required workflow declares read-only contents permission, disables persisted
+  checkout credentials, and pins every third-party action to an immutable commit.
+- Propagation coverage proves the workflow and shared parser travel together.
+
 ## [3.9.2] - 2026-08-05
 **Windows bash portability, one resolver; MANIFEST project-name preservation**
 
@@ -471,7 +507,8 @@ independently of the npm version).
 ### Changed
 - Relicensed to Apache-2.0 (earlier commits carried MIT, then CC BY 4.0, headers).
 
-[Unreleased]: https://github.com/homeofe/AAHP/compare/v3.9.2...HEAD
+[Unreleased]: https://github.com/homeofe/AAHP/compare/v3.10.0...HEAD
+[3.10.0]: https://github.com/homeofe/AAHP/compare/v3.9.2...v3.10.0
 [3.9.2]: https://github.com/homeofe/AAHP/compare/v3.9.1...v3.9.2
 [3.9.1]: https://github.com/homeofe/AAHP/compare/v3.9.0...v3.9.1
 [3.9.0]: https://github.com/homeofe/AAHP/compare/v3.8.3...v3.9.0

--- a/README.md
+++ b/README.md
@@ -340,23 +340,60 @@ up to 4 layers:
    unparseable manifest, an index that lists no files, or a missing checksum
    tool. `lint-handoff.sh` still runs for the checks this layer does not cover
    (injection, secrets, PII, stale lock) and its non-zero exit still blocks.
-2. **Content-drift gate (the key check)** - if the change set touches any source
-   file OUTSIDE `.ai/handoff/`, it MUST also include `STATUS.md` AND a regenerated
-   `MANIFEST.json`. Otherwise it HARD-FAILS with:
-   `Code changed but handoff state did not. Run /handoff.`
+2. **Content-drift gate (the key check)** - if the change set touches any
+   handoff-impacting file OUTSIDE `.ai/handoff/`, it MUST also include
+   `STATUS.md` AND a regenerated `MANIFEST.json`. Otherwise it HARD-FAILS with:
+   `Handoff-impacting files changed but handoff state did not. Run /handoff.`
+   Every outside file is impacting by default. A repository may classify an
+   exact regular tracked file as non-impacting under `handoffImpact` in
+   `aahp.config.json`, but only a content modification (`M`) uses that reviewed
+   exception. Additions, deletions, renames, copies, type changes, config edits,
+   handoff edits, and any mixed source change remain impacting. The gate logs
+   every applied classification with its required review reason.
 3. **Commit-pointer freshness** - `MANIFEST.last_session.commit` vs HEAD.
 4. **TRUST-TTL expiry** - reports expired `verified` rows (advisory).
 
 ```bash
 ./scripts/verify-handoff.sh [path] --level precommit   # fast: layers 1-2
 ./scripts/verify-handoff.sh [path] --level prepush      # full: layers 1-4
-./scripts/verify-handoff.sh [path] --level ci           # full, no escape hatch
+./scripts/verify-handoff.sh [path] --level ci --base SHA # full, explicit diff base
 ```
 
 **Wiring.** `scripts/install-hooks.sh` installs a git `pre-commit` hook (fast:
 checksum + drift gate) and a `pre-push` hook (full verify + TTL). A CI workflow
 (`.github/workflows/aahp-verify.yml`) runs `aahp verify --level ci` as the
-intended REQUIRED status check, the non-bypassable off-machine backstop.
+intended REQUIRED status check, the non-bypassable off-machine backstop. The
+workflow passes the pull request base SHA on pull requests and the event's
+`before` SHA on pushes. At `--level ci`, a missing, all-zero, unreadable,
+invalid, or HEAD-equal base and every failed git diff are blocking failures.
+`AAHP_BASE_SHA` is the environment equivalent of `--base`. The gate compares
+the base and HEAD endpoint trees, rather than a merge-base three-dot range, so
+rollback and force-push events cannot collapse into an empty diff.
+
+**Reviewed non-impacting modifications.** This optional configuration is for
+files whose content cannot describe product or implementation state, such as a
+dependency update schedule. Each entry is one exact repo-relative regular tracked file
+and a non-empty reason:
+
+```json
+{
+  "handoffImpact": {
+    "nonImpactingModifiedFiles": [
+      {
+        "file": ".github/dependabot.yml",
+        "reason": "Dependency update scheduling does not describe product or implementation state."
+      }
+    ]
+  }
+}
+```
+
+The runtime parser fails closed even when schema validation is not installed.
+It rejects malformed types, empty reasons, absolute or traversal paths, glob
+or metacharacter paths, directories, untracked paths, symlinks, gitlinks,
+`.ai/handoff/**`,
+`aahp.config.json`, duplicates, and prefix-like ambiguity. An absent section
+preserves the original all-files-impacting behavior.
 
 **Verify-only.** The gate never regenerates `MANIFEST.json`. Regeneration stays a
 separate `/handoff` step. The gate only detects drift and tells you to run it.
@@ -799,6 +836,21 @@ a different way, by publishing the shapes it is known to miss (Section 8.7).
 check` gate list, and it exits 0 whatever it finds. The non-enforcement is structural
 rather than a default that could drift back. Gates keep binary pass/fail; a rule that
 cannot be sound does not become one.
+
+### ADR-018: Layer 2 exceptions are exact, reviewed, M-only, and CI is base-anchored
+**Why it recurs:** a blanket actor or directory exemption is easy to add when a
+maintenance-only change makes handoff regeneration feel noisy, and a CI checkout can
+silently compare HEAD with HEAD when it guesses its own base. Either shortcut turns a
+required green check into a statement about work it never examined. **Decision:** every
+outside file remains handoff-impacting unless `aahp.config.json` names that exact regular tracked
+file with a non-empty review reason. Only git status `M` can use the exception; every
+other status and every mixed change still requires the handoff pair. CI never guesses:
+the workflow supplies an event base, and a missing, zero, invalid, unreadable, HEAD-equal,
+or undiffable base fails closed. The endpoint trees are compared directly so a rollback
+or force-push cannot select HEAD as its own merge base. Layer 1 runs for every actor.
+**Consequence:** narrow
+maintenance changes avoid unrelated handoff churn without creating an identity bypass,
+path-pattern bypass, or vacuous required check.
 
 ---
 
@@ -1410,7 +1462,9 @@ adding an `aahp.config.json` (see `schema/aahp-config.schema.json` and
 pins capability numbers across surfaces, `forbiddenPatterns` denylists text (for example the
 em-dash ban), `docSync` keeps duplicated value-sets in step, `docLinks` checks internal
 Markdown links, and `generate` drives an optional LOG release-journal plus a
-`NEXT_ACTIONS.md` current-version freshness gate. Two selection keys tune the surface:
+`NEXT_ACTIONS.md` current-version freshness gate. `handoffImpact` carries the reviewed,
+exact-file, M-only Layer 2 classifications described in Section 2.8. Two selection keys
+tune the surface:
 `check` (`only`/`skip`) chooses which gates `aahp check` runs, and `pinnedDep`
 (`name`/`location`/`allowRange`) opts the `doctor` pinned-dep gate in (absent, it is a clean
 skip). `acceptanceCriteria` (`include`/`manifest`) supplies the input paths for the

--- a/README.md
+++ b/README.md
@@ -345,9 +345,10 @@ up to 4 layers:
    `STATUS.md` AND a regenerated `MANIFEST.json`. Otherwise it HARD-FAILS with:
    `Handoff-impacting files changed but handoff state did not. Run /handoff.`
    Every outside file is impacting by default. A repository may classify an
-   exact regular tracked file as non-impacting under `handoffImpact` in
-   `aahp.config.json`, but only a content modification (`M`) uses that reviewed
-   exception. Additions, deletions, renames, copies, type changes, config edits,
+   exact regular tracked file as non-impacting under `handoffImpact` in a regular
+   tracked `aahp.config.json`, but only a content-only modification (`M`) whose
+   Git file mode is unchanged uses that reviewed exception. Additions, deletions,
+   renames, copies, type changes, config edits,
    handoff edits, and any mixed source change remain impacting. The gate logs
    every applied classification with its required review reason.
 3. **Commit-pointer freshness** - `MANIFEST.last_session.commit` vs HEAD.
@@ -362,7 +363,13 @@ up to 4 layers:
 **Wiring.** `scripts/install-hooks.sh` installs a git `pre-commit` hook (fast:
 checksum + drift gate) and a `pre-push` hook (full verify + TTL). A CI workflow
 (`.github/workflows/aahp-verify.yml`) runs `aahp verify --level ci` as the
-intended REQUIRED status check, the non-bypassable off-machine backstop. The
+intended REQUIRED off-machine status check. `AAHP_SKIP_VERIFY` cannot disable that
+CI-level invocation. However, the supplied `pull_request` workflow and vendored gate
+execute from the proposed branch, so the check is not an independent trust boundary by
+itself. Repository rules must require trusted review for changes to the workflow,
+`verify-handoff.sh`, `_aahp-lib.sh`, and the scripts they execute (or an operator must
+provide a default-branch evaluator). v3.10.0 does not ship that repository-specific
+review/ruleset configuration. The
 workflow passes the pull request base SHA on pull requests and the event's
 `before` SHA on pushes. At `--level ci`, a missing, all-zero, unreadable,
 invalid, or HEAD-equal base and every failed git diff are blocking failures.
@@ -373,7 +380,7 @@ rollback and force-push events cannot collapse into an empty diff.
 **Reviewed non-impacting modifications.** This optional configuration is for
 files whose content cannot describe product or implementation state, such as a
 dependency update schedule. Each entry is one exact repo-relative regular tracked file
-and a non-empty reason:
+and a review reason containing a Unicode letter or number:
 
 ```json
 {
@@ -389,8 +396,9 @@ and a non-empty reason:
 ```
 
 The runtime parser fails closed even when schema validation is not installed.
-It rejects malformed types, empty reasons, absolute or traversal paths, glob
-or metacharacter paths, directories, untracked paths, symlinks, gitlinks,
+It rejects malformed types and non-standard constants, empty or invisible reasons,
+control and format characters, absolute or traversal paths, glob or metacharacter paths,
+directories, untracked paths, symlinks, gitlinks, mode changes,
 `.ai/handoff/**`,
 `aahp.config.json`, duplicates, and prefix-like ambiguity. An absent section
 preserves the original all-files-impacting behavior.
@@ -398,9 +406,10 @@ preserves the original all-files-impacting behavior.
 **Verify-only.** The gate never regenerates `MANIFEST.json`. Regeneration stays a
 separate `/handoff` step. The gate only detects drift and tells you to run it.
 
-**Escape hatch.** `AAHP_SKIP_VERIFY=1` skips LOCAL verification only. It is
-caught by the required CI check (which ignores the hatch), so do NOT use it to
-bypass CI. Never use `git commit/push --no-verify`.
+**Escape hatch.** `AAHP_SKIP_VERIFY=1` skips LOCAL verification only. The CI-level
+invocation ignores the hatch. This prevents the environment-variable bypass, but the
+required-check evaluator paths still need the trusted-review boundary described above.
+Never use `git commit/push --no-verify`.
 
 See `scripts/ROLLOUT.md` for the propagation plan across consumer repos.
 
@@ -750,8 +759,8 @@ release-journal generator is an opt-in consumer capability that must not target 
 ### ADR-005: the PII allowlist is PII-only and never a verify bypass
 **Why it recurs:** an agent extending the allowlist could broaden it into a general
 bypass. **Decision:** the allowlist is exact-match, expiring, reviewed, and suppresses
-only the matching PII finding; secret detection and every other verify layer stay
-non-bypassable. (Backed by regression tests.)
+only the matching PII finding; secret detection and every other verify layer remain
+unaffected by the allowlist. (Backed by regression tests.)
 
 ### ADR-006: TRUST-TTL lives in TRUST.md, not MANIFEST.json
 **Why it recurs:** `MANIFEST.json` looks like the "obvious" home for structured TTL
@@ -761,8 +770,9 @@ human-auditable trust record in one human-readable file.
 ### ADR-007: gate severities are fixed (drift blocks, TTL warns, escape hatch is local-only)
 **Why it recurs:** each severity is a knob an agent could flip while "tuning" the gate.
 **Decision:** the content-drift gate hard-fails; TRUST-TTL is advisory (warn); and
-`AAHP_SKIP_VERIFY` is honored locally but ignored at `--level ci`, so the required check
-can never be bypassed.
+`AAHP_SKIP_VERIFY` is honored locally but ignored at `--level ci`, so that environment
+variable cannot skip the required invocation. The pull-request evaluator paths still
+need trusted-review protection as described in Section 2.8.
 
 ### ADR-008: aahp_version is independent of the npm version
 **Why it recurs:** at release time an agent may reflexively bump `aahp_version` to match
@@ -795,7 +805,8 @@ gate runner whose exit code drives CI. The shared gates are intentional, not red
 **Why it recurs:** wiring a hook to one hard-coded path is the quick way. **Decision:**
 the hooks run `scripts/verify-handoff.sh` when it is vendored, else the installed `aahp`
 CLI via `npx --no-install`, and skip when neither resolves. The local hook is a
-convenience; the required CI check is the non-bypassable authority.
+convenience; the required CI check is the off-machine authority after its evaluator
+paths receive the trusted-review protection described in Section 2.8.
 
 ### ADR-014: enumerating gates scan git-tracked files and fail loud off-tree
 **Why it recurs:** a plain filesystem walk looks simpler than shelling out to git.
@@ -842,8 +853,9 @@ cannot be sound does not become one.
 maintenance-only change makes handoff regeneration feel noisy, and a CI checkout can
 silently compare HEAD with HEAD when it guesses its own base. Either shortcut turns a
 required green check into a statement about work it never examined. **Decision:** every
-outside file remains handoff-impacting unless `aahp.config.json` names that exact regular tracked
-file with a non-empty review reason. Only git status `M` can use the exception; every
+outside file remains handoff-impacting unless a regular tracked `aahp.config.json` names that
+exact regular tracked file with a review reason containing a visible letter or number. Only a
+content-only git status `M` whose old and new regular-file modes are identical can use the exception; every
 other status and every mixed change still requires the handoff pair. CI never guesses:
 the workflow supplies an event base, and a missing, zero, invalid, unreadable, HEAD-equal,
 or undiffable base fails closed. The endpoint trees are compared directly so a rollback
@@ -1316,8 +1328,8 @@ your-project/
       grounding-auditor.md  # the Phase 4.5 auditor persona
 ```
 
-- **Hooks.** `scripts/install-hooks.sh` (shipped by AAHP) installs the pre-commit and pre-push hooks; the harness runs it once at setup. The hooks resolve the vendored `scripts/verify-handoff.sh` first, fall back to the installed `aahp` CLI via `npx --no-install` when it is absent, and skip when neither resolves (the required CI check is the non-bypassable backstop). See Section 2.8.
-- **CI.** Copy `.github/workflows/aahp-verify.yml`; it runs `aahp verify --level ci` (no escape hatch) and should be a required status check. For governance (changelog, version sync, forbidden patterns, doc links) copy the portable `.github/workflows/aahp-govern.yml` beside it, or let `aahp init --gates` scaffold it; it runs `aahp check` through the pinned devDependency via `npx` and is verify-only.
+- **Hooks.** `scripts/install-hooks.sh` (shipped by AAHP) installs the pre-commit and pre-push hooks; the harness runs it once at setup. The hooks resolve the vendored `scripts/verify-handoff.sh` first, fall back to the installed `aahp` CLI via `npx --no-install` when it is absent, and skip when neither resolves (the required CI check is the off-machine backstop once its evaluator paths are protected). See Section 2.8.
+- **CI.** Copy `.github/workflows/aahp-verify.yml`; it runs `aahp verify --level ci` (no escape hatch) and should be a required status check. Also require trusted review for the workflow and its vendored gate/parser paths, because a `pull_request` workflow otherwise evaluates code from the proposed branch. For governance (changelog, version sync, forbidden patterns, doc links) copy the portable `.github/workflows/aahp-govern.yml` beside it, or let `aahp init --gates` scaffold it; it runs `aahp check` through the pinned devDependency via `npx` and is verify-only.
 - **Referencing scripts.** Harness commands invoke AAHP by the vendored script path (`bash scripts/verify-handoff.sh . --level prepush`) or the CLI (`npx aahp verify`). They never reimplement the checks.
 
 ### 9.3 Minimal harness bootstrap

--- a/aahp.config.example.json
+++ b/aahp.config.example.json
@@ -47,6 +47,14 @@
     "include": [".ai/handoff/NEXT_ACTIONS.md"],
     "manifest": ".ai/handoff/MANIFEST.json"
   },
+  "handoffImpact": {
+    "nonImpactingModifiedFiles": [
+      {
+        "file": ".github/dependabot.yml",
+        "reason": "Dependency update scheduling does not describe product or implementation state."
+      }
+    ]
+  },
   "check": {
     "skip": ["claims"]
   },

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -87,6 +87,7 @@ Manifest options:
 
 Verify options:
   --level LEVEL     Layers to run: precommit|prepush|full|ci (default: full)
+  --base SHA        Exact Layer 2 base commit (required at --level ci)
   --quiet           Suppress per-check OK output, keep failures
 
 Doctor options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elvatis_com/aahp",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elvatis_com/aahp",
-      "version": "3.9.2",
+      "version": "3.10.0",
       "license": "Apache-2.0",
       "bin": {
         "aahp": "bin/aahp.js"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bin/",
     "scripts/",
     "!scripts/ROLLOUT.md",
+    ".github/workflows/aahp-verify.yml",
     "assets/",
     "templates/",
     "schema/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvatis_com/aahp",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "description": "AI-to-AI Handoff Protocol - CLI tools for managing agent handoff files",
   "author": "Elvatis <emre.kohler@elvatis.com>",
   "bin": {

--- a/schema/aahp-config.schema.json
+++ b/schema/aahp-config.schema.json
@@ -280,8 +280,11 @@
               "reason": {
                 "type": "string",
                 "minLength": 1,
-                "pattern": "\\S",
-                "description": "Non-empty review rationale explaining why modifying this file cannot stale handoff state."
+                "pattern": "[\\p{L}\\p{N}]",
+                "not": {
+                  "pattern": "[\\p{Cc}\\p{Cf}]"
+                },
+                "description": "Review rationale explaining why modifying this file cannot stale handoff state. It must contain a Unicode letter or number and cannot contain control or invisible format characters."
               }
             },
             "additionalProperties": false

--- a/schema/aahp-config.schema.json
+++ b/schema/aahp-config.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/homeofe/AAHP/schema/aahp-config.schema.json",
   "title": "AAHP Config",
-  "description": "Optional aahp.config.json consumed by the config-driven AAHP release gates (version-sync, changelog, claims, generator) and by aahp doctor. Every section is optional; an absent file or section makes the corresponding gate a no-op.",
+  "description": "Optional aahp.config.json consumed by the config-driven AAHP release gates, aahp doctor, and the verify gate's reviewed handoff-impact classifier. Every section is optional; absent configuration preserves each command's default behavior.",
   "type": "object",
   "properties": {
     "$schema": {
@@ -243,6 +243,49 @@
         "manifest": {
           "type": "string",
           "description": "Path to the task registry that supplies task status (default .ai/handoff/MANIFEST.json), relative to the project root and required to resolve inside it. A value that escapes the root is reported as manifest-outside-root and is never opened. Absent, the done-state rule is skipped rather than guessed."
+        }
+      },
+      "additionalProperties": false
+    },
+    "handoffImpact": {
+      "type": "object",
+      "description": "Reviewed exact-file exceptions for the Layer 2 content-drift gate. Only a modification (git status M) of a listed regular tracked file is non-impacting; additions, deletions, renames, copies, type changes, and mixed source changes remain impacting.",
+      "required": [
+        "nonImpactingModifiedFiles"
+      ],
+      "properties": {
+        "nonImpactingModifiedFiles": {
+          "type": "array",
+          "description": "Exact repo-relative regular tracked files whose content-only modification does not change handoff state. Runtime validation rejects duplicates and prefix-like ambiguity and rejects directories, symlinks, and gitlinks.",
+          "items": {
+            "type": "object",
+            "required": [
+              "file",
+              "reason"
+            ],
+            "properties": {
+              "file": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9._@+ -]+(?:/[A-Za-z0-9._@+ -]+)*$",
+                "not": {
+                  "anyOf": [
+                    { "pattern": "^aahp\\.config\\.json$" },
+                    { "pattern": "^\\.ai/handoff(?:/|$)" },
+                    { "pattern": "(?:^|/)\\.{1,2}(?:/|$)" }
+                  ]
+                },
+                "description": "Exact repo-relative regular tracked file. Forward slashes only; no absolute paths, traversal, glob syntax, directories, symlinks, gitlinks, handoff files, or aahp.config.json."
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "\\S",
+                "description": "Non-empty review rationale explaining why modifying this file cannot stale handoff state."
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/scripts/ROLLOUT.md
+++ b/scripts/ROLLOUT.md
@@ -40,15 +40,27 @@ first so the repo starts from a clean, in-sync state.
    compares everything except the file that was dropped from it).
    The gate computes those verdicts itself; `lint-handoff.sh` also runs and its
    exit code still blocks, but no Layer 1 verdict is read out of its output.
-2. Content-drift gate (THE key check): if a commit/push changes any source file
-   OUTSIDE `.ai/handoff/`, it MUST also include `STATUS.md` AND a regenerated
-   `MANIFEST.json`, else FAIL: "Code changed but handoff state did not. Run /handoff."
+2. Content-drift gate (THE key check): if a commit/push changes any
+   handoff-impacting file OUTSIDE `.ai/handoff/`, it MUST also include
+   `STATUS.md` AND a regenerated `MANIFEST.json`, else FAIL. Every outside file
+   is impacting by default. A consumer may review an exact regular tracked file into
+   `handoffImpact.nonImpactingModifiedFiles`, with a non-empty reason, but only
+   git status `M` uses that classification. A/D/R/C and mixed source changes
+   remain impacting. CI receives an explicit event base and fails closed when
+   the base or diff cannot be proven.
+   The comparison is base-to-HEAD, not merge-base-to-HEAD, so a rollback or
+   force-push remains visible instead of collapsing to an empty three-dot diff.
 3. Commit-pointer freshness (`MANIFEST.last_session.commit` vs HEAD).
 4. TRUST-TTL expiry (advisory).
 
 ## Defaults (do not change without an ADR)
 
 - Drift gate HARD-FAILS (exit 1). It does not warn.
+- Layer 1 runs for every actor. Do not add an actor-wide dependency-bot bypass.
+- At `--level ci`, pass the pull request base SHA or push event `before` SHA.
+  Missing, zero, invalid, unreadable, HEAD-equal, and undiffable bases fail.
+- Non-impacting classifications are exact regular tracked files with review reasons,
+  never directories, globs, actors, or change types other than `M`.
 - TRUST-TTL expiry is advisory (warn) and never blocks a commit on its own.
 - Escape hatch `AAHP_SKIP_VERIFY=1` skips LOCAL verification only. It is caught
   by the required CI check (`aahp verify --level ci`, which ignores the hatch).
@@ -173,6 +185,9 @@ the rollout can answer "what is left" without the answer living in public.
 - [ ] `bash scripts/install-hooks.sh .`
 - [ ] Run `/handoff` if `aahp verify --level full` reports drift.
 - [ ] Confirm `aahp verify --level full` is green.
+- [ ] If the consumer needs a non-impacting classification, review each exact regular
+      file and reason in `aahp.config.json`; verify A/D/R/C and a mixed change
+      still fail before accepting it.
 - [ ] Commit (the gate will enforce that STATUS.md + MANIFEST.json move with it).
 - [ ] When CI is available: set `aahp-verify` as a required check.
 - [ ] Record the outcome in the private fleet list, including deliberate skips.

--- a/scripts/ROLLOUT.md
+++ b/scripts/ROLLOUT.md
@@ -62,9 +62,11 @@ first so the repo starts from a clean, in-sync state.
 - Non-impacting classifications are exact regular tracked files with review reasons,
   never directories, globs, actors, or change types other than `M`.
 - TRUST-TTL expiry is advisory (warn) and never blocks a commit on its own.
-- Escape hatch `AAHP_SKIP_VERIFY=1` skips LOCAL verification only. It is caught
-  by the required CI check (`aahp verify --level ci`, which ignores the hatch).
-  Do NOT use it to bypass CI. Never use `git commit/push --no-verify`.
+- Escape hatch `AAHP_SKIP_VERIFY=1` skips LOCAL verification only. The required
+  CI invocation ignores the hatch. Protect the workflow, gate, parser, and invoked
+  scripts with trusted review, because a pull-request workflow otherwise evaluates
+  the proposed branch. Do NOT use the hatch to bypass CI. Never use
+  `git commit/push --no-verify`.
 - CI activation: if hosted CI is currently unavailable to you (cost controls, a
   paused plan, a migration to self-hosted runners), commit the workflow anyway.
   It activates by itself the moment CI is switched back on, and until then the
@@ -190,4 +192,8 @@ the rollout can answer "what is left" without the answer living in public.
       still fail before accepting it.
 - [ ] Commit (the gate will enforce that STATUS.md + MANIFEST.json move with it).
 - [ ] When CI is available: set `aahp-verify` as a required check.
+- [ ] Require trusted review (CODEOWNERS or an equivalent ruleset) for
+      `.github/workflows/aahp-verify.yml`, `scripts/verify-handoff.sh`,
+      `scripts/_aahp-lib.sh`, and every script the workflow executes; the supplied
+      pull-request workflow is not an independent trust boundary without it.
 - [ ] Record the outcome in the private fleet list, including deliberate skips.

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -300,8 +300,8 @@ aahp_non_impacting_modified_files() {
               if (typeof file !== "string" || file.length === 0 || file.trim() !== file) {
                 fail(`${label}.file must be a non-empty, trimmed string`);
               }
-              if (typeof reason !== "string" || reason.trim().length === 0 || /[\u0000-\u001f\u007f]/.test(reason)) {
-                fail(`${label}.reason must be a non-empty reviewable string without control characters`);
+              if (typeof reason !== "string" || !/[\p{L}\p{N}]/u.test(reason) || /[\p{Cc}\p{Cf}]/u.test(reason)) {
+                fail(`${label}.reason must contain a letter or number and no control or format characters`);
               }
               if (/^[\\/]/.test(file) || /^[A-Za-z]:/.test(file) || file.includes("\\")) {
                 fail(`${label}.file must be repo-relative and use forward slashes`);
@@ -331,7 +331,7 @@ aahp_non_impacting_modified_files() {
     py=$(aahp_python_cmd)
     [ -n "$py" ] || return 2
     "$py" -c '
-import json, re, sys
+import json, re, sys, unicodedata
 
 def fail(message):
     raise ValueError(message)
@@ -345,7 +345,11 @@ def no_duplicate_keys(pairs):
     return result
 
 with open(sys.argv[1], encoding="utf-8") as handle:
-    cfg = json.load(handle, object_pairs_hook=no_duplicate_keys)
+    cfg = json.load(
+        handle,
+        object_pairs_hook=no_duplicate_keys,
+        parse_constant=lambda value: fail("non-standard JSON constant: " + value),
+    )
 if not isinstance(cfg, dict):
     fail("top level must be an object")
 if "handoffImpact" not in cfg:
@@ -369,8 +373,12 @@ for index, entry in enumerate(entries):
     reason = entry["reason"]
     if not isinstance(file, str) or not file or file.strip() != file:
         fail(label + ".file must be a non-empty, trimmed string")
-    if not isinstance(reason, str) or not reason.strip() or re.search(r"[\x00-\x1f\x7f]", reason):
-        fail(label + ".reason must be a non-empty reviewable string without control characters")
+    if (
+        not isinstance(reason, str)
+        or not any(char.isalnum() for char in reason)
+        or any(unicodedata.category(char) in ("Cc", "Cf") for char in reason)
+    ):
+        fail(label + ".reason must contain a letter or number and no control or format characters")
     if file.startswith(("/", "\\")) or re.match(r"^[A-Za-z]:", file) or "\\" in file:
         fail(label + ".file must be repo-relative and use forward slashes")
     if not re.fullmatch(r"[A-Za-z0-9._@+ -]+(?:/[A-Za-z0-9._@+ -]+)*", file):

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -184,6 +184,206 @@ out.flush()
 ' "$manifest" || return 1
 }
 
+# Read and validate the reviewed Layer 2 exception list from aahp.config.json.
+# Echoes one TAB-separated "<file>\t<reason>" line per exact file entry.
+#
+# The parser deliberately validates the complete handoffImpact shape here,
+# rather than trusting an optional external schema command. verify-handoff.sh
+# is propagated into repositories that may have only Node or Python available,
+# and a required CI gate must fail closed on malformed configuration.
+#
+# Paths use a conservative, cross-platform repo-relative grammar. This keeps
+# every entry literal and reviewable: no pathspec magic, globbing, traversal,
+# control characters, or platform-dependent separators can enter the git
+# classifier. The caller separately proves each returned path is a tracked
+# file, not a directory.
+#
+# Exit codes:
+#   0 = config absent, section absent, or section valid
+#   1 = config unreadable, malformed, or invalid
+#   2 = no JSON interpreter available (neither node nor python)
+aahp_non_impacting_modified_files() {
+    local config="$1"
+    if [ ! -e "$config" ] && [ ! -L "$config" ]; then
+        return 0
+    fi
+    [ -f "$config" ] && [ -r "$config" ] || {
+        echo "aahp.config.json is not a readable regular file" >&2
+        return 1
+    }
+
+    if command -v node &>/dev/null; then
+        node -e '
+            const fs = require("fs");
+            const fail = (message) => { throw new Error(message); };
+            const text = fs.readFileSync(process.argv[1], "utf8");
+            const cfg = JSON.parse(text);
+
+            // JSON.parse silently keeps the last duplicate object key. That is
+            // unsafe for a reviewed policy file: the key a reviewer sees first
+            // may not be the value the gate enforces. The input is known-valid
+            // JSON at this point, so a small recursive scanner can reject every
+            // duplicate key without becoming a second permissive parser.
+            let cursor = 0;
+            const whitespace = () => { while (/\s/.test(text[cursor] || "")) cursor += 1; };
+            const stringToken = () => {
+              const start = cursor;
+              cursor += 1;
+              while (cursor < text.length) {
+                if (text[cursor] === "\\") { cursor += 2; continue; }
+                if (text[cursor] === "\"") { cursor += 1; return JSON.parse(text.slice(start, cursor)); }
+                cursor += 1;
+              }
+              fail("unterminated JSON string");
+            };
+            const value = () => {
+              whitespace();
+              if (text[cursor] === "{") return object();
+              if (text[cursor] === "[") {
+                cursor += 1; whitespace();
+                if (text[cursor] === "]") { cursor += 1; return; }
+                while (true) {
+                  value(); whitespace();
+                  if (text[cursor] === "]") { cursor += 1; return; }
+                  cursor += 1;
+                }
+              }
+              if (text[cursor] === "\"") { stringToken(); return; }
+              while (cursor < text.length && !/[\s,}\]]/.test(text[cursor])) cursor += 1;
+            };
+            const object = () => {
+              cursor += 1; whitespace();
+              const keys = new Set();
+              if (text[cursor] === "}") { cursor += 1; return; }
+              while (true) {
+                const key = stringToken();
+                if (keys.has(key)) fail(`duplicate JSON object key: ${key}`);
+                keys.add(key);
+                whitespace(); cursor += 1; value(); whitespace();
+                if (text[cursor] === "}") { cursor += 1; return; }
+                cursor += 1; whitespace();
+              }
+            };
+            value();
+            if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) {
+              fail("top level must be an object");
+            }
+            if (!Object.prototype.hasOwnProperty.call(cfg, "handoffImpact")) process.exit(0);
+            const impact = cfg.handoffImpact;
+            if (!impact || typeof impact !== "object" || Array.isArray(impact)) {
+              fail("handoffImpact must be an object");
+            }
+            const impactKeys = Object.keys(impact);
+            if (impactKeys.some((key) => key !== "nonImpactingModifiedFiles")) {
+              fail("handoffImpact contains an unknown property");
+            }
+            const entries = impact.nonImpactingModifiedFiles;
+            if (!Array.isArray(entries)) {
+              fail("handoffImpact.nonImpactingModifiedFiles must be an array");
+            }
+            const seen = [];
+            for (let index = 0; index < entries.length; index += 1) {
+              const entry = entries[index];
+              const label = `handoffImpact.nonImpactingModifiedFiles[${index}]`;
+              if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+                fail(`${label} must be an object`);
+              }
+              const keys = Object.keys(entry);
+              if (keys.length !== 2 || !keys.includes("file") || !keys.includes("reason")) {
+                fail(`${label} must contain exactly file and reason`);
+              }
+              const file = entry.file;
+              const reason = entry.reason;
+              if (typeof file !== "string" || file.length === 0 || file.trim() !== file) {
+                fail(`${label}.file must be a non-empty, trimmed string`);
+              }
+              if (typeof reason !== "string" || reason.trim().length === 0 || /[\u0000-\u001f\u007f]/.test(reason)) {
+                fail(`${label}.reason must be a non-empty reviewable string without control characters`);
+              }
+              if (/^[\\/]/.test(file) || /^[A-Za-z]:/.test(file) || file.includes("\\")) {
+                fail(`${label}.file must be repo-relative and use forward slashes`);
+              }
+              if (!/^[A-Za-z0-9._@+ -]+(?:\/[A-Za-z0-9._@+ -]+)*$/.test(file)) {
+                fail(`${label}.file contains a glob or unsupported metacharacter`);
+              }
+              const parts = file.split("/");
+              if (parts.some((part) => part === "." || part === "..")) {
+                fail(`${label}.file must not contain dot or traversal segments`);
+              }
+              const folded = file.toLowerCase();
+              if (folded === "aahp.config.json" || folded === ".ai/handoff" || folded.startsWith(".ai/handoff/")) {
+                fail(`${label}.file cannot classify the config or handoff state as non-impacting`);
+              }
+              if (seen.some((prior) => prior === folded || prior.startsWith(folded) || folded.startsWith(prior))) {
+                fail(`${label}.file duplicates or ambiguously prefixes another entry`);
+              }
+              seen.push(folded);
+              process.stdout.write(file + "\t" + reason.trim() + "\n");
+            }
+        ' "$config" || return 1
+        return 0
+    fi
+
+    local py
+    py=$(aahp_python_cmd)
+    [ -n "$py" ] || return 2
+    "$py" -c '
+import json, re, sys
+
+def fail(message):
+    raise ValueError(message)
+
+def no_duplicate_keys(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            fail("duplicate JSON object key: " + key)
+        result[key] = value
+    return result
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    cfg = json.load(handle, object_pairs_hook=no_duplicate_keys)
+if not isinstance(cfg, dict):
+    fail("top level must be an object")
+if "handoffImpact" not in cfg:
+    raise SystemExit(0)
+impact = cfg["handoffImpact"]
+if not isinstance(impact, dict):
+    fail("handoffImpact must be an object")
+if any(key != "nonImpactingModifiedFiles" for key in impact):
+    fail("handoffImpact contains an unknown property")
+entries = impact.get("nonImpactingModifiedFiles")
+if not isinstance(entries, list):
+    fail("handoffImpact.nonImpactingModifiedFiles must be an array")
+seen = []
+for index, entry in enumerate(entries):
+    label = "handoffImpact.nonImpactingModifiedFiles[%d]" % index
+    if not isinstance(entry, dict):
+        fail(label + " must be an object")
+    if set(entry) != {"file", "reason"}:
+        fail(label + " must contain exactly file and reason")
+    file = entry["file"]
+    reason = entry["reason"]
+    if not isinstance(file, str) or not file or file.strip() != file:
+        fail(label + ".file must be a non-empty, trimmed string")
+    if not isinstance(reason, str) or not reason.strip() or re.search(r"[\x00-\x1f\x7f]", reason):
+        fail(label + ".reason must be a non-empty reviewable string without control characters")
+    if file.startswith(("/", "\\")) or re.match(r"^[A-Za-z]:", file) or "\\" in file:
+        fail(label + ".file must be repo-relative and use forward slashes")
+    if not re.fullmatch(r"[A-Za-z0-9._@+ -]+(?:/[A-Za-z0-9._@+ -]+)*", file):
+        fail(label + ".file contains a glob or unsupported metacharacter")
+    if any(part in (".", "..") for part in file.split("/")):
+        fail(label + ".file must not contain dot or traversal segments")
+    folded = file.lower()
+    if folded == "aahp.config.json" or folded == ".ai/handoff" or folded.startswith(".ai/handoff/"):
+        fail(label + ".file cannot classify the config or handoff state as non-impacting")
+    if any(prior == folded or prior.startswith(folded) or folded.startswith(prior) for prior in seen):
+        fail(label + ".file duplicates or ambiguously prefixes another entry")
+    seen.append(folded)
+    sys.stdout.buffer.write((file + "\t" + reason.strip() + "\n").encode("utf-8"))
+' "$config" || return 1
+}
+
 # Report expired "verified" trust rows from a TRUST.md file.
 # Trust tables are Markdown with a header row that includes "Status" and
 # "Expires" columns. We locate those columns from the header, then for each

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -207,12 +207,15 @@ aahp_non_impacting_modified_files() {
     if [ ! -e "$config" ] && [ ! -L "$config" ]; then
         return 0
     fi
-    [ -f "$config" ] && [ -r "$config" ] || {
+    if [ ! -f "$config" ] || [ ! -r "$config" ]; then
         echo "aahp.config.json is not a readable regular file" >&2
         return 1
-    }
+    fi
 
     if command -v node &>/dev/null; then
+        # Single quotes are intentional: the embedded JavaScript contains
+        # template literals whose ${...} expressions belong to Node, not bash.
+        # shellcheck disable=SC2016
         node -e '
             const fs = require("fs");
             const fail = (message) => { throw new Error(message); };

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -28,6 +28,9 @@
 #                     prepush   - full verify + TTL (layers 1-4)
 #                     full      - all layers (alias for prepush)
 #                     ci        - all layers, no escape hatch honoured
+#   --base SHA      Exact base commit for the Layer 2 diff. Required at level
+#                   ci; optional at other non-precommit levels. The equivalent
+#                   environment variable is AAHP_BASE_SHA.
 #   --quiet         Suppress per-check OK output, keep failures
 #   --help, -h      Show this help
 #
@@ -42,7 +45,7 @@
 #
 # Defaults (documented):
 #   - The drift gate HARD-FAILS (exit 1), it does not warn.
-#   - Commit-pointer freshness is advisory at precommit, hard at prepush/ci.
+#   - Commit-pointer freshness is advisory at prepush/full/ci (not run at precommit).
 #   - TRUST-TTL expiry is advisory (warn) by default; it never blocks a commit.
 
 set -euo pipefail
@@ -55,6 +58,9 @@ source "$SCRIPT_DIR/_aahp-lib.sh"
 
 LEVEL="full"
 QUIET=false
+BASE_SHA="${AAHP_BASE_SHA:-}"
+BASE_EXPLICIT=false
+[ -n "$BASE_SHA" ] && BASE_EXPLICIT=true
 
 # First positional arg is project root (if it does not start with --)
 PROJECT_ROOT="."
@@ -65,7 +71,14 @@ fi
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --level)  LEVEL="$2"; shift 2 ;;
+        --level)
+            [ $# -ge 2 ] || { echo "Error: --level requires a value" >&2; exit 1; }
+            LEVEL="$2"; shift 2
+            ;;
+        --base)
+            [ $# -ge 2 ] || { echo "Error: --base requires a SHA" >&2; exit 1; }
+            BASE_SHA="$2"; BASE_EXPLICIT=true; shift 2
+            ;;
         --quiet)  QUIET=true; shift ;;
         --help|-h)
             sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
@@ -73,7 +86,7 @@ while [ $# -gt 0 ]; do
             ;;
         *)
             echo "Unknown option: $1" >&2
-            echo "Usage: verify-handoff.sh [path-to-project] [--level precommit|prepush|full|ci] [--quiet]" >&2
+            echo "Usage: verify-handoff.sh [path-to-project] [--level precommit|prepush|full|ci] [--base SHA] [--quiet]" >&2
             exit 1
             ;;
     esac
@@ -291,60 +304,257 @@ fi
 #
 # Change set selection by level:
 #   precommit -> staged changes (git diff --cached)
-#   prepush/full/ci -> committed changes not yet on the upstream/base
-#                      (fallback to staged + last commit if no upstream)
+#   prepush/full -> explicit --base/AAHP_BASE_SHA when supplied, else committed
+#                   changes not yet on the upstream/base (fallback to staged +
+#                   last commit if no upstream)
+#   ci -> explicit --base/AAHP_BASE_SHA, with every missing, zero, unreadable,
+#         self-referential, or failed diff treated as a blocking failure
 
 echo ""
 echo -e "${GREEN}[Layer 2]${NC} Content-drift gate (code changed => handoff must change)"
 
 git_in_repo() { git -C "$PROJECT_ROOT" rev-parse --git-dir &>/dev/null 2>&1; }
 
-CHANGED_FILES=""
+CHANGED_RECORDS=""
+DIFF_FAILED=0
 if git_in_repo; then
     if [ "$LEVEL" = "precommit" ]; then
-        CHANGED_FILES=$(git -C "$PROJECT_ROOT" diff --cached --name-only 2>/dev/null || true)
+        if ! CHANGED_RECORDS=$(git -C "$PROJECT_ROOT" diff --cached --name-status --find-renames --find-copies --find-copies-harder 2>&1); then
+            log_fail "Could not compute the staged Layer 2 diff."
+            echo "$CHANGED_RECORDS" | sed '/^$/d' | sed 's/^/    /' | head -10
+            FAILURES=$((FAILURES + 1))
+            DIFF_FAILED=1
+            CHANGED_RECORDS=""
+        fi
     else
-        # Prefer the upstream tracking branch; fall back to origin/main; then
-        # fall back to the last commit so the gate still has something to read.
         BASE_REF=""
-        if git -C "$PROJECT_ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null 2>&1; then
+        if [ "$BASE_EXPLICIT" = true ]; then
+            BASE_REF="$BASE_SHA"
+        elif [ "$LEVEL" = "ci" ]; then
+            log_fail "Level ci requires an explicit base commit via --base SHA or AAHP_BASE_SHA."
+            echo "    CI must pass the pull request base SHA or push event before SHA."
+            FAILURES=$((FAILURES + 1))
+            DIFF_FAILED=1
+        # Prefer the upstream tracking branch; fall back to origin/main; then
+        # fall back to the last commit so local full/prepush runs still work.
+        elif git -C "$PROJECT_ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null 2>&1; then
             BASE_REF=$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}')
         elif git -C "$PROJECT_ROOT" rev-parse --verify origin/main &>/dev/null 2>&1; then
             BASE_REF="origin/main"
         fi
+
         if [ -n "$BASE_REF" ]; then
-            CHANGED_FILES=$(git -C "$PROJECT_ROOT" diff --name-only "$BASE_REF"...HEAD 2>/dev/null || true)
-        else
-            CHANGED_FILES=$(git -C "$PROJECT_ROOT" diff --name-only HEAD~1...HEAD 2>/dev/null \
-                || git -C "$PROJECT_ROOT" show --name-only --pretty=format: HEAD 2>/dev/null || true)
+            BASE_COMMIT=""
+            if [ "$BASE_EXPLICIT" = true ] && [[ ! "$BASE_REF" =~ ^[0-9A-Fa-f]{7,40}$ ]]; then
+                log_fail "The explicit Layer 2 base must be a hexadecimal commit SHA."
+                FAILURES=$((FAILURES + 1))
+                DIFF_FAILED=1
+            elif [ "$BASE_EXPLICIT" = true ] && [[ "$BASE_REF" =~ ^0+$ ]]; then
+                log_fail "The explicit Layer 2 base cannot be the all-zero SHA."
+                FAILURES=$((FAILURES + 1))
+                DIFF_FAILED=1
+            elif ! BASE_COMMIT=$(git -C "$PROJECT_ROOT" rev-parse --verify "$BASE_REF^{commit}" 2>/dev/null); then
+                log_fail "The Layer 2 base commit is missing, unreadable, or invalid: $BASE_REF"
+                FAILURES=$((FAILURES + 1))
+                DIFF_FAILED=1
+            else
+                HEAD_COMMIT=$(git -C "$PROJECT_ROOT" rev-parse --verify 'HEAD^{commit}' 2>/dev/null || true)
+                if [ "$LEVEL" = "ci" ] && [ "$BASE_COMMIT" = "$HEAD_COMMIT" ]; then
+                    log_fail "The required CI base resolves to HEAD, which would make Layer 2 vacuous."
+                    echo "    Pull requests must pass the base SHA; pushes must pass the event before SHA."
+                    FAILURES=$((FAILURES + 1))
+                    DIFF_FAILED=1
+                # Compare the two endpoint trees, not merge-base...HEAD. A push
+                # can move a branch backwards or across histories; in that
+                # case three-dot diff can select HEAD itself as the merge base
+                # and return an empty, vacuous change set for a real rollback.
+                elif ! CHANGED_RECORDS=$(git -C "$PROJECT_ROOT" diff --name-status --find-renames --find-copies --find-copies-harder "$BASE_COMMIT" HEAD 2>&1); then
+                    log_fail "Could not compute the Layer 2 diff from base $BASE_REF to HEAD."
+                    echo "$CHANGED_RECORDS" | sed '/^$/d' | sed 's/^/    /' | head -10
+                    FAILURES=$((FAILURES + 1))
+                    DIFF_FAILED=1
+                    CHANGED_RECORDS=""
+                fi
+            fi
+        elif [ "$DIFF_FAILED" -eq 0 ]; then
+            if ! CHANGED_RECORDS=$(git -C "$PROJECT_ROOT" diff --name-status --find-renames --find-copies --find-copies-harder HEAD~1...HEAD 2>&1); then
+                if ! CHANGED_RECORDS=$(git -C "$PROJECT_ROOT" show --name-status --find-renames --find-copies --find-copies-harder --pretty=format: HEAD 2>&1); then
+                    log_fail "Could not compute a fallback Layer 2 diff."
+                    echo "$CHANGED_RECORDS" | sed '/^$/d' | sed 's/^/    /' | head -10
+                    FAILURES=$((FAILURES + 1))
+                    DIFF_FAILED=1
+                    CHANGED_RECORDS=""
+                fi
+            fi
         fi
+
         # Include staged-but-uncommitted changes too, so a "full" run in a dirty
         # tree still sees pending source edits.
-        STAGED=$(git -C "$PROJECT_ROOT" diff --cached --name-only 2>/dev/null || true)
-        CHANGED_FILES=$(printf '%s\n%s\n' "$CHANGED_FILES" "$STAGED" | sort -u | sed '/^$/d')
+        if [ "$DIFF_FAILED" -eq 0 ]; then
+            if ! STAGED=$(git -C "$PROJECT_ROOT" diff --cached --name-status --find-renames --find-copies --find-copies-harder 2>&1); then
+                log_fail "Could not compute the staged Layer 2 diff."
+                echo "$STAGED" | sed '/^$/d' | sed 's/^/    /' | head -10
+                FAILURES=$((FAILURES + 1))
+                DIFF_FAILED=1
+            else
+                CHANGED_RECORDS=$(printf '%s\n%s\n' "$CHANGED_RECORDS" "$STAGED" | sort -u | sed '/^$/d')
+            fi
+        fi
     fi
 else
-    log_warn "Not a git repo. Skipping drift gate."
+    log_fail "Not a git repository. Layer 2 cannot compute a diff."
+    FAILURES=$((FAILURES + 1))
+    DIFF_FAILED=1
 fi
 
-if git_in_repo; then
-    # Source files = anything tracked that is NOT under .ai/handoff/.
-    # Doc-only handoff churn under .ai/handoff/ never triggers the gate.
-    CODE_CHANGED=$(echo "$CHANGED_FILES" | grep -v '^\.ai/handoff/' | sed '/^$/d' || true)
-    HANDOFF_CHANGED=$(echo "$CHANGED_FILES" | grep '^\.ai/handoff/' | sed '/^$/d' || true)
+if git_in_repo && [ "$DIFF_FAILED" -eq 0 ]; then
+    NON_IMPACTING_CONFIG=""
+    CONFIG_VALID=1
+    # Layer 2 must classify a change against policy from the SAME snapshot.
+    # Reading an untracked or unstaged working-tree config while inspecting the
+    # staged/index diff would let a policy that is not in the commit authorize
+    # that commit. Fail closed instead; a fully staged config matches the index.
+    if [ -e "aahp.config.json" ] || [ -L "aahp.config.json" ]; then
+        CONFIG_INDEX_MATCH=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-files --error-unmatch -- "aahp.config.json" 2>/dev/null || true)
+        if [ "$CONFIG_INDEX_MATCH" != "aahp.config.json" ]; then
+            log_fail "aahp.config.json exists in the working tree but is not tracked in the index."
+            echo "    Layer 2 will not apply policy that is absent from the change snapshot."
+            FAILURES=$((FAILURES + 1))
+            CONFIG_VALID=0
+        fi
+        CONFIG_DIFF_RC=0
+        git -C "$PROJECT_ROOT" diff --quiet -- "aahp.config.json" || CONFIG_DIFF_RC=$?
+        if [ "$CONFIG_DIFF_RC" -eq 1 ]; then
+            log_fail "aahp.config.json has unstaged changes."
+            echo "    Stage or discard them so Layer 2 policy matches the inspected change snapshot."
+            FAILURES=$((FAILURES + 1))
+            CONFIG_VALID=0
+        elif [ "$CONFIG_DIFF_RC" -gt 1 ]; then
+            log_fail "Could not prove aahp.config.json matches the inspected change snapshot."
+            FAILURES=$((FAILURES + 1))
+            CONFIG_VALID=0
+        fi
+    fi
 
-    if [ -z "$CODE_CHANGED" ]; then
-        log_ok "No source files changed outside .ai/handoff/. Drift gate not triggered."
-    else
-        STATUS_TOUCHED=$(echo "$HANDOFF_CHANGED" | grep -E '(^|/)\.ai/handoff/STATUS\.md$|^\.ai/handoff/STATUS\.md$' || true)
-        MANIFEST_TOUCHED=$(echo "$HANDOFF_CHANGED" | grep -E '^\.ai/handoff/MANIFEST\.json$' || true)
+    if ! declare -F aahp_non_impacting_modified_files >/dev/null 2>&1; then
+        log_fail "scripts/_aahp-lib.sh is out of date: helper 'aahp_non_impacting_modified_files' is missing."
+        FAILURES=$((FAILURES + 1))
+        CONFIG_VALID=0
+    elif [ "$CONFIG_VALID" -eq 1 ]; then
+        CONFIG_RC=0
+        NON_IMPACTING_CONFIG=$(aahp_non_impacting_modified_files "aahp.config.json" 2>&1) || CONFIG_RC=$?
+        if [ "$CONFIG_RC" -eq 2 ]; then
+            log_fail "No JSON interpreter available to validate handoffImpact configuration."
+            FAILURES=$((FAILURES + 1))
+            CONFIG_VALID=0
+        elif [ "$CONFIG_RC" -ne 0 ]; then
+            log_fail "aahp.config.json has invalid handoffImpact configuration."
+            echo "$NON_IMPACTING_CONFIG" | sed '/^$/d' | sed 's/^/    /' | head -10
+            FAILURES=$((FAILURES + 1))
+            CONFIG_VALID=0
+        fi
+    fi
 
-        if [ -n "$STATUS_TOUCHED" ] && [ -n "$MANIFEST_TOUCHED" ]; then
-            log_ok "Code changed and handoff state (STATUS.md + MANIFEST.json) changed with it."
+    if [ "$CONFIG_VALID" -eq 1 ] && [ -n "$NON_IMPACTING_CONFIG" ]; then
+        while IFS=$'\t' read -r configured_file configured_reason; do
+            [ -n "$configured_file" ] || continue
+            if [ -d "$configured_file" ]; then
+                log_fail "Configured non-impacting path is a directory, not an exact file: $configured_file"
+                FAILURES=$((FAILURES + 1))
+                CONFIG_VALID=0
+                continue
+            fi
+            TRACKED_MATCH=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-files --error-unmatch -- "$configured_file" 2>/dev/null || true)
+            HEAD_MATCH=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-tree -r --name-only HEAD -- "$configured_file" 2>/dev/null || true)
+            if [ "$TRACKED_MATCH" != "$configured_file" ] && [ "$HEAD_MATCH" != "$configured_file" ]; then
+                log_fail "Configured non-impacting path is not one exact tracked file: $configured_file"
+                FAILURES=$((FAILURES + 1))
+                CONFIG_VALID=0
+            fi
+            INDEX_MODE_RC=0
+            HEAD_MODE_RC=0
+            INDEX_MODE_ENTRY=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-files -s -- "$configured_file" 2>/dev/null) || INDEX_MODE_RC=$?
+            HEAD_MODE_ENTRY=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-tree HEAD -- "$configured_file" 2>/dev/null) || HEAD_MODE_RC=$?
+            INDEX_MODE=$(printf '%s\n' "$INDEX_MODE_ENTRY" | sed -n '1s/ .*//p')
+            HEAD_MODE=$(printf '%s\n' "$HEAD_MODE_ENTRY" | sed -n '1s/ .*//p')
+            if [ "$INDEX_MODE_RC" -ne 0 ] || [ "$HEAD_MODE_RC" -ne 0 ] || { [ -z "$INDEX_MODE" ] && [ -z "$HEAD_MODE" ]; }; then
+                log_fail "Could not prove configured non-impacting path is a regular tracked file: $configured_file"
+                FAILURES=$((FAILURES + 1))
+                CONFIG_VALID=0
+            fi
+            for tracked_mode in "$INDEX_MODE" "$HEAD_MODE"; do
+                [ -n "$tracked_mode" ] || continue
+                case "$tracked_mode" in
+                    100644|100755) ;;
+                    *)
+                        log_fail "Configured non-impacting path is not a regular tracked file: $configured_file (mode $tracked_mode)"
+                        echo "    Symlinks, gitlinks, and unexpected file modes remain handoff-impacting."
+                        FAILURES=$((FAILURES + 1))
+                        CONFIG_VALID=0
+                        ;;
+                esac
+            done
+        done <<< "$NON_IMPACTING_CONFIG"
+    fi
+
+    IMPACTING_CHANGED=""
+    STATUS_TOUCHED=""
+    MANIFEST_TOUCHED=""
+    while IFS=$'\t' read -r change_status path_one path_two; do
+        [ -n "$change_status" ] || continue
+
+        # A rename or copy has two paths and always remains impacting. Added,
+        # deleted, renamed, copied, type-changed, and unmerged states can never
+        # use the reviewed M-only exception.
+        if [[ "$change_status" == R* || "$change_status" == C* ]]; then
+            DISPLAY_CHANGE="$change_status $path_one -> $path_two"
+            CHANGE_PATHS=$(printf '%s\n%s\n' "$path_one" "$path_two")
         else
-            log_fail "Code changed but handoff state did not. Run /handoff."
-            echo "    Source files changed outside .ai/handoff/:"
-            echo "$CODE_CHANGED" | sed 's/^/      - /' | head -20
+            DISPLAY_CHANGE="$change_status $path_one"
+            CHANGE_PATHS="$path_one"
+        fi
+
+        OUTSIDE_HANDOFF=""
+        while IFS= read -r changed_path; do
+            [ -n "$changed_path" ] || continue
+            case "$changed_path" in
+                .ai/handoff/STATUS.md) STATUS_TOUCHED=1 ;;
+                .ai/handoff/MANIFEST.json) MANIFEST_TOUCHED=1 ;;
+            esac
+            case "$changed_path" in
+                .ai/handoff/*) ;;
+                *) OUTSIDE_HANDOFF=1 ;;
+            esac
+        done <<< "$CHANGE_PATHS"
+        [ -n "$OUTSIDE_HANDOFF" ] || continue
+
+        CLASSIFIED_REASON=""
+        if [ "$CONFIG_VALID" -eq 1 ] && [ "$change_status" = "M" ] && [ -z "$path_two" ]; then
+            while IFS=$'\t' read -r configured_file configured_reason; do
+                if [ "$configured_file" = "$path_one" ]; then
+                    CLASSIFIED_REASON="$configured_reason"
+                    break
+                fi
+            done <<< "$NON_IMPACTING_CONFIG"
+        fi
+
+        if [ -n "$CLASSIFIED_REASON" ]; then
+            log_ok "Reviewed non-impacting modification: $path_one"
+            echo "    Reason: $CLASSIFIED_REASON"
+        else
+            IMPACTING_CHANGED="${IMPACTING_CHANGED}${DISPLAY_CHANGE}"$'\n'
+        fi
+    done <<< "$CHANGED_RECORDS"
+
+    if [ -z "$IMPACTING_CHANGED" ]; then
+        log_ok "No handoff-impacting files changed outside .ai/handoff/. Drift gate not triggered."
+    else
+        if [ -n "$STATUS_TOUCHED" ] && [ -n "$MANIFEST_TOUCHED" ]; then
+            log_ok "Handoff-impacting files changed and handoff state (STATUS.md + MANIFEST.json) changed with them."
+        else
+            log_fail "Handoff-impacting files changed but handoff state did not. Run /handoff."
+            echo "    Impacting changes outside .ai/handoff/:"
+            echo "$IMPACTING_CHANGED" | sed '/^$/d' | sed 's/^/      - /' | head -20
             [ -z "$STATUS_TOUCHED" ]   && echo "    Missing: .ai/handoff/STATUS.md update"
             [ -z "$MANIFEST_TOUCHED" ] && echo "    Missing: regenerated .ai/handoff/MANIFEST.json"
             FAILURES=$((FAILURES + 1))
@@ -355,7 +565,7 @@ fi
 # --- Layer 3: Commit-pointer freshness -------------------------
 # MANIFEST.last_session.commit should point at (a recent) HEAD, proving the
 # manifest was regenerated against the code it describes.
-# Advisory at precommit (HEAD is about to move); hard at prepush/full/ci.
+# Not run at precommit (HEAD is about to move); advisory at prepush/full/ci.
 
 if [ "$LEVEL" != "precommit" ]; then
     echo ""

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -100,6 +100,11 @@ case "$LEVEL" in
         ;;
 esac
 
+if [ "$BASE_EXPLICIT" = true ] && [ -z "$BASE_SHA" ]; then
+    echo "Error: --base requires a non-empty commit SHA" >&2
+    exit 1
+fi
+
 # Path-format-agnostic file access (cross-platform fix).
 # Windows-native Python/Node cannot open an absolute MSYS path like
 # /c/Users/...; helpers that read MANIFEST.json (aahp_manifest_field) would
@@ -317,6 +322,7 @@ git_in_repo() { git -C "$PROJECT_ROOT" rev-parse --git-dir &>/dev/null 2>&1; }
 
 CHANGED_RECORDS=""
 DIFF_FAILED=0
+DIFF_OLD_TREE="HEAD"
 if git_in_repo; then
     if [ "$LEVEL" = "precommit" ]; then
         if ! CHANGED_RECORDS=$(git -C "$PROJECT_ROOT" diff --cached --name-status --find-renames --find-copies --find-copies-harder 2>&1); then
@@ -374,6 +380,8 @@ if git_in_repo; then
                     FAILURES=$((FAILURES + 1))
                     DIFF_FAILED=1
                     CHANGED_RECORDS=""
+                else
+                    DIFF_OLD_TREE="$BASE_COMMIT"
                 fi
             fi
         elif [ "$DIFF_FAILED" -eq 0 ]; then
@@ -385,6 +393,8 @@ if git_in_repo; then
                     DIFF_FAILED=1
                     CHANGED_RECORDS=""
                 fi
+            else
+                DIFF_OLD_TREE=$(git -C "$PROJECT_ROOT" rev-parse --verify 'HEAD~1^{commit}' 2>/dev/null || printf 'HEAD')
             fi
         fi
 
@@ -419,6 +429,14 @@ if git_in_repo && [ "$DIFF_FAILED" -eq 0 ]; then
         if [ "$CONFIG_INDEX_MATCH" != "aahp.config.json" ]; then
             log_fail "aahp.config.json exists in the working tree but is not tracked in the index."
             echo "    Layer 2 will not apply policy that is absent from the change snapshot."
+            FAILURES=$((FAILURES + 1))
+            CONFIG_VALID=0
+        fi
+        CONFIG_INDEX_ENTRY=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-files -s -- "aahp.config.json" 2>/dev/null || true)
+        CONFIG_INDEX_MODE=$(printf '%s\n' "$CONFIG_INDEX_ENTRY" | sed -n '1s/ .*//p')
+        if [ "$CONFIG_INDEX_MODE" != "100644" ] && [ "$CONFIG_INDEX_MODE" != "100755" ]; then
+            log_fail "aahp.config.json is not a regular tracked file (mode ${CONFIG_INDEX_MODE:-unknown})."
+            echo "    Layer 2 will not follow a symlink or read policy from another Git object type."
             FAILURES=$((FAILURES + 1))
             CONFIG_VALID=0
         fi
@@ -472,17 +490,17 @@ if git_in_repo && [ "$DIFF_FAILED" -eq 0 ]; then
                 CONFIG_VALID=0
             fi
             INDEX_MODE_RC=0
-            HEAD_MODE_RC=0
+            OLD_MODE_RC=0
             INDEX_MODE_ENTRY=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-files -s -- "$configured_file" 2>/dev/null) || INDEX_MODE_RC=$?
-            HEAD_MODE_ENTRY=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-tree HEAD -- "$configured_file" 2>/dev/null) || HEAD_MODE_RC=$?
+            OLD_MODE_ENTRY=$(git -C "$PROJECT_ROOT" --literal-pathspecs ls-tree "$DIFF_OLD_TREE" -- "$configured_file" 2>/dev/null) || OLD_MODE_RC=$?
             INDEX_MODE=$(printf '%s\n' "$INDEX_MODE_ENTRY" | sed -n '1s/ .*//p')
-            HEAD_MODE=$(printf '%s\n' "$HEAD_MODE_ENTRY" | sed -n '1s/ .*//p')
-            if [ "$INDEX_MODE_RC" -ne 0 ] || [ "$HEAD_MODE_RC" -ne 0 ] || { [ -z "$INDEX_MODE" ] && [ -z "$HEAD_MODE" ]; }; then
+            OLD_MODE=$(printf '%s\n' "$OLD_MODE_ENTRY" | sed -n '1s/ .*//p')
+            if [ "$INDEX_MODE_RC" -ne 0 ] || [ "$OLD_MODE_RC" -ne 0 ] || { [ -z "$INDEX_MODE" ] && [ -z "$OLD_MODE" ]; }; then
                 log_fail "Could not prove configured non-impacting path is a regular tracked file: $configured_file"
                 FAILURES=$((FAILURES + 1))
                 CONFIG_VALID=0
             fi
-            for tracked_mode in "$INDEX_MODE" "$HEAD_MODE"; do
+            for tracked_mode in "$INDEX_MODE" "$OLD_MODE"; do
                 [ -n "$tracked_mode" ] || continue
                 case "$tracked_mode" in
                     100644|100755) ;;
@@ -494,6 +512,12 @@ if git_in_repo && [ "$DIFF_FAILED" -eq 0 ]; then
                         ;;
                 esac
             done
+            if [ -n "$INDEX_MODE" ] && [ -n "$OLD_MODE" ] && [ "$INDEX_MODE" != "$OLD_MODE" ]; then
+                log_fail "Configured non-impacting path changed Git mode: $configured_file ($OLD_MODE -> $INDEX_MODE)"
+                echo "    The reviewed M-only exception permits content changes, not executable-bit changes."
+                FAILURES=$((FAILURES + 1))
+                CONFIG_VALID=0
+            fi
         done <<< "$NON_IMPACTING_CONFIG"
     fi
 

--- a/tests/handoff-impact.bats
+++ b/tests/handoff-impact.bats
@@ -1,0 +1,400 @@
+#!/usr/bin/env bats
+# handoff-impact.bats - Layer 2 reviewed exceptions and fail-closed base tests.
+
+setup() {
+    load test_helper
+    setup
+}
+
+teardown() {
+    teardown
+}
+
+write_impact_config() {
+    local file="$1"
+    local reason="${2:-Reviewed maintenance-only file.}"
+    node -e '
+const fs = require("fs");
+const config = {handoffImpact:{nonImpactingModifiedFiles:[{file:process.argv[2],reason:process.argv[3]}]}};
+fs.writeFileSync(process.argv[1], JSON.stringify(config, null, 2) + "\n");
+' "$TEST_TMPDIR/aahp.config.json" "$file" "$reason"
+}
+
+parse_impact_config() {
+    bash -c 'source "$1"; aahp_non_impacting_modified_files "$2"' _ \
+        "$SCRIPTS_DIR/_aahp-lib.sh" "$TEST_TMPDIR/aahp.config.json"
+}
+
+prepare_gate_baseline() {
+    create_full_handoff
+    git -C "$TEST_TMPDIR" add -A
+    git -C "$TEST_TMPDIR" commit -q -m "seed handoff"
+    bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet --phase implementation
+    git -C "$TEST_TMPDIR" add -A
+    git -C "$TEST_TMPDIR" commit -q -m "manifest"
+    CI_BASE="$(git -C "$TEST_TMPDIR" rev-parse HEAD~1)"
+}
+
+commit_reviewed_file() {
+    local file="$1"
+    mkdir -p "$(dirname "$TEST_TMPDIR/$file")"
+    printf 'baseline\n' > "$TEST_TMPDIR/$file"
+    write_impact_config "$file"
+    git -C "$TEST_TMPDIR" add "$file" aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "configure reviewed file"
+}
+
+@test "config parser accepts one exact file and emits its trimmed reason" {
+    write_impact_config "docs/maintenance.md" "  Reviewed maintenance-only file.  "
+    run parse_impact_config
+    [ "$status" -eq 0 ]
+    [ "$output" = $'docs/maintenance.md\tReviewed maintenance-only file.' ]
+}
+
+@test "config parser rejects malformed shapes, unsafe paths, and ambiguous entries" {
+    local cases=(
+        '{'
+        '[]'
+        '{"handoffImpact":[]}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":{}}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[[]]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"   "}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"/tmp/a","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"C:/tmp/a","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"../a","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/*.md","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a?.md","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":".ai/handoff/STATUS.md","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"aahp.config.json","reason":"x"}]}}'
+        '{"handoffImpact":{"unknown":[],"nonImpactingModifiedFiles":[]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[]},"handoffImpact":{"nonImpactingModifiedFiles":[]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","file":"docs/b.md","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"x","reason":"y"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"x"},{"file":"DOCS/A.MD","reason":"y"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a","reason":"x"},{"file":"docs/a.md","reason":"y"}]}}'
+    )
+    local value
+    for value in "${cases[@]}"; do
+        printf '%s\n' "$value" > "$TEST_TMPDIR/aahp.config.json"
+        run parse_impact_config
+        [ "$status" -ne 0 ]
+    done
+}
+
+@test "Python fallback also rejects duplicate JSON keys" {
+    local fallback_lib="$TEST_TMPDIR/fallback-lib.sh"
+    cp "$SCRIPTS_DIR/_aahp-lib.sh" "$fallback_lib"
+    sed '0,/if command -v node .*then/s//if false; then/' "$fallback_lib" > "$fallback_lib.tmp"
+    mv "$fallback_lib.tmp" "$fallback_lib"
+    printf '%s\n' '{"handoffImpact":{"nonImpactingModifiedFiles":[]},"handoffImpact":{"nonImpactingModifiedFiles":[]}}' \
+        > "$TEST_TMPDIR/aahp.config.json"
+
+    run bash -c 'source "$1"; aahp_non_impacting_modified_files "$2"' _ \
+        "$fallback_lib" "$TEST_TMPDIR/aahp.config.json"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"duplicate JSON object key: handoffImpact"* ]]
+}
+
+@test "absent handoffImpact config preserves the original impacting behavior" {
+    prepare_gate_baseline
+    printf 'source\n' > "$TEST_TMPDIR/source.js"
+    git -C "$TEST_TMPDIR" add source.js
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Handoff-impacting files changed but handoff state did not"* ]]
+}
+
+@test "an exact M-only reviewed file passes and logs file plus reason" {
+    prepare_gate_baseline
+    commit_reviewed_file "docs/maintenance.md"
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/maintenance.md"
+    git -C "$TEST_TMPDIR" add docs/maintenance.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Reviewed non-impacting modification: docs/maintenance.md"* ]]
+    [[ "$output" == *"Reason: Reviewed maintenance-only file."* ]]
+}
+
+@test "a mixed reviewed modification and source change still triggers drift" {
+    prepare_gate_baseline
+    commit_reviewed_file "docs/maintenance.md"
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/maintenance.md"
+    printf 'source\n' > "$TEST_TMPDIR/source.js"
+    git -C "$TEST_TMPDIR" add docs/maintenance.md source.js
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Reviewed non-impacting modification: docs/maintenance.md"* ]]
+    [[ "$output" == *"A source.js"* ]]
+}
+
+@test "an untracked working-tree config cannot authorize a staged modification" {
+    prepare_gate_baseline
+    mkdir -p "$TEST_TMPDIR/docs"
+    printf 'baseline\n' > "$TEST_TMPDIR/docs/sensitive.md"
+    git -C "$TEST_TMPDIR" add docs/sensitive.md
+    git -C "$TEST_TMPDIR" commit -q -m "tracked source"
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/sensitive.md"
+    git -C "$TEST_TMPDIR" add docs/sensitive.md
+    write_impact_config "docs/sensitive.md"
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"exists in the working tree but is not tracked in the index"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+}
+
+@test "an unstaged exception in a tracked config cannot authorize a staged modification" {
+    prepare_gate_baseline
+    mkdir -p "$TEST_TMPDIR/docs"
+    printf 'baseline\n' > "$TEST_TMPDIR/docs/sensitive.md"
+    printf '{"handoffImpact":{"nonImpactingModifiedFiles":[]}}\n' > "$TEST_TMPDIR/aahp.config.json"
+    git -C "$TEST_TMPDIR" add docs/sensitive.md aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "tracked source and policy"
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/sensitive.md"
+    git -C "$TEST_TMPDIR" add docs/sensitive.md
+    write_impact_config "docs/sensitive.md"
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"aahp.config.json has unstaged changes"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+}
+
+@test "a configured added file remains impacting" {
+    prepare_gate_baseline
+    write_impact_config "docs/new.md"
+    git -C "$TEST_TMPDIR" add aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "configure future file"
+    mkdir -p "$TEST_TMPDIR/docs"
+    printf 'new\n' > "$TEST_TMPDIR/docs/new.md"
+    git -C "$TEST_TMPDIR" add docs/new.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"A docs/new.md"* ]]
+}
+
+@test "a configured deleted file remains impacting" {
+    prepare_gate_baseline
+    commit_reviewed_file "docs/maintenance.md"
+    git -C "$TEST_TMPDIR" rm -q docs/maintenance.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"D docs/maintenance.md"* ]]
+}
+
+@test "a configured renamed file remains impacting" {
+    prepare_gate_baseline
+    commit_reviewed_file "docs/maintenance.md"
+    git -C "$TEST_TMPDIR" mv docs/maintenance.md docs/renamed.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"R100 docs/maintenance.md -> docs/renamed.md"* ]]
+}
+
+@test "a configured copied file remains impacting" {
+    prepare_gate_baseline
+    mkdir -p "$TEST_TMPDIR/docs"
+    printf 'same content\n' > "$TEST_TMPDIR/docs/source.md"
+    write_impact_config "docs/copy.md"
+    git -C "$TEST_TMPDIR" add docs/source.md aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "configure future copy"
+    cp "$TEST_TMPDIR/docs/source.md" "$TEST_TMPDIR/docs/copy.md"
+    git -C "$TEST_TMPDIR" add docs/copy.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"C100 docs/source.md -> docs/copy.md"* ]]
+}
+
+@test "a configured directory is rejected even when it contains tracked files" {
+    prepare_gate_baseline
+    mkdir -p "$TEST_TMPDIR/docs"
+    printf 'tracked\n' > "$TEST_TMPDIR/docs/a.md"
+    write_impact_config "docs"
+    git -C "$TEST_TMPDIR" add docs/a.md aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "configure invalid directory"
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"is a directory, not an exact file"* ]]
+}
+
+@test "tracked symlink and gitlink modes cannot receive the M-only classification" {
+    prepare_gate_baseline
+    local blob head
+    blob="$(printf 'target\n' | git -C "$TEST_TMPDIR" hash-object -w --stdin)"
+    head="$(git -C "$TEST_TMPDIR" rev-parse HEAD)"
+
+    write_impact_config "docs/link"
+    git -C "$TEST_TMPDIR" add aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "configure symlink path"
+    git -C "$TEST_TMPDIR" update-index --add --cacheinfo "120000,$blob,docs/link"
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not a regular tracked file: docs/link (mode 120000)"* ]]
+
+    git -C "$TEST_TMPDIR" update-index --force-remove docs/link
+    write_impact_config "modules/component"
+    git -C "$TEST_TMPDIR" add aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "configure gitlink path"
+    git -C "$TEST_TMPDIR" update-index --add --cacheinfo "160000,$head,modules/component"
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not a regular tracked file: modules/component (mode 160000)"* ]]
+}
+
+@test "level ci rejects missing, zero, unreadable, and HEAD-equal bases" {
+    prepare_gate_baseline
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"requires an explicit base commit"* ]]
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base 0000000000000000000000000000000000000000
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"all-zero SHA"* ]]
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base ffffffffffffffffffffffffffffffffffffffff
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing, unreadable, or invalid"* ]]
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$(git -C "$TEST_TMPDIR" rev-parse HEAD)"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"base resolves to HEAD"* ]]
+}
+
+@test "AAHP_BASE_SHA supplies a valid non-vacuous CI base" {
+    prepare_gate_baseline
+    AAHP_BASE_SHA="$CI_BASE" run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"aahp verify passed"* ]]
+}
+
+@test "a descendant base exposes rollback changes instead of a vacuous three-dot diff" {
+    prepare_gate_baseline
+    local original descendant
+    original="$(git -C "$TEST_TMPDIR" rev-parse HEAD)"
+    printf 'rolled back source\n' > "$TEST_TMPDIR/rollback.js"
+    git -C "$TEST_TMPDIR" add rollback.js
+    git -C "$TEST_TMPDIR" commit -q -m "future commit"
+    descendant="$(git -C "$TEST_TMPDIR" rev-parse HEAD)"
+    git -C "$TEST_TMPDIR" checkout -q --detach "$original"
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$descendant"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"D rollback.js"* ]]
+    [[ "$output" == *"Handoff-impacting files changed but handoff state did not"* ]]
+}
+
+@test "a git diff failure is a blocking CI failure" {
+    prepare_gate_baseline
+    local real_git stub_bin stub_path
+    real_git="$(command -v git)"
+    stub_bin="$TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub_bin"
+    stub_path="$stub_bin"
+    if command -v cygpath &>/dev/null; then
+        stub_path="$(cygpath -u "$stub_bin")"
+    fi
+    cat > "$stub_bin/git" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+    if [ "\$arg" = "diff" ]; then
+        echo "forced diff failure" >&2
+        exit 42
+    fi
+done
+exec "$real_git" "\$@"
+EOF
+    chmod +x "$stub_bin/git"
+
+    run env PATH="$stub_path:$PATH" bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Could not compute the Layer 2 diff"* ]]
+    [[ "$output" == *"forced diff failure"* ]]
+}
+
+@test "required workflow always runs and passes event base SHA" {
+    run grep -n -E 'dependabot|author\.username|github\.actor' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+    [ "$status" -eq 1 ]
+
+    run grep -n 'AAHP_BASE_SHA.*pull_request.base.sha.*event.before.*inputs.base' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+    [ "$status" -eq 0 ]
+
+    run grep -Ec 'uses: actions/(checkout|setup-node|setup-python)@[0-9a-f]{40} # v' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 3 ]
+    run grep -nE 'uses: .*@v[0-9]' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+    [ "$status" -eq 1 ]
+    grep -q 'permissions:' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+    grep -q 'contents: read' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+    grep -q 'persist-credentials: false' "$AAHP_ROOT/.github/workflows/aahp-verify.yml"
+}
+
+@test "CLI help documents the explicit verify base" {
+    run node "$AAHP_ROOT/bin/aahp.js" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--base SHA"* ]]
+    [[ "$output" == *"required at --level ci"* ]]
+}
+
+@test "config example validates against the config schema" {
+    local entry
+    entry="$(cd "$AAHP_ROOT" && node -e '
+try {
+  const path = require("path");
+  const pkg = require("ajv-cli/package.json");
+  const dir = path.dirname(require.resolve("ajv-cli/package.json"));
+  const bin = typeof pkg.bin === "string" ? pkg.bin : pkg.bin.ajv;
+  process.stdout.write(path.resolve(dir, bin));
+} catch (e) {}
+' 2>/dev/null)"
+    [ -n "$entry" ] || skip "ajv-cli not installed"
+
+    run node "$entry" validate --spec=draft2020 -c ajv-formats \
+        -s "$AAHP_ROOT/schema/aahp-config.schema.json" \
+        -d "$AAHP_ROOT/aahp.config.example.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"valid"* ]]
+}
+
+@test "config schema rejects malformed impact entries and unsafe path shapes" {
+    local entry
+    entry="$(cd "$AAHP_ROOT" && node -e '
+try {
+  const path = require("path");
+  const pkg = require("ajv-cli/package.json");
+  const dir = path.dirname(require.resolve("ajv-cli/package.json"));
+  const bin = typeof pkg.bin === "string" ? pkg.bin : pkg.bin.ajv;
+  process.stdout.write(path.resolve(dir, bin));
+} catch (e) {}
+' 2>/dev/null)"
+    [ -n "$entry" ] || skip "ajv-cli not installed"
+
+    local cases=(
+        '{"handoffImpact":{"nonImpactingModifiedFiles":{}}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"   "}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"/tmp/a","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"../a","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/*.md","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":".ai/handoff/STATUS.md","reason":"x"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"aahp.config.json","reason":"x"}]}}'
+    )
+    local value
+    for value in "${cases[@]}"; do
+        printf '%s\n' "$value" > "$TEST_TMPDIR/invalid-config.json"
+        run node "$entry" validate --spec=draft2020 -c ajv-formats \
+            -s "$AAHP_ROOT/schema/aahp-config.schema.json" \
+            -d "$TEST_TMPDIR/invalid-config.json"
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"invalid"* ]]
+    done
+}

--- a/tests/handoff-impact.bats
+++ b/tests/handoff-impact.bats
@@ -25,6 +25,19 @@ parse_impact_config() {
         "$SCRIPTS_DIR/_aahp-lib.sh" "$TEST_TMPDIR/aahp.config.json"
 }
 
+make_python_fallback_lib() {
+    local fallback_lib="$TEST_TMPDIR/fallback-lib.sh"
+    cp "$SCRIPTS_DIR/_aahp-lib.sh" "$fallback_lib"
+    sed '0,/if command -v node .*then/s//if false; then/' "$fallback_lib" > "$fallback_lib.tmp"
+    mv "$fallback_lib.tmp" "$fallback_lib"
+    printf '%s\n' "$fallback_lib"
+}
+
+parse_impact_config_with_lib() {
+    bash -c 'source "$1"; aahp_non_impacting_modified_files "$2"' _ \
+        "$1" "$TEST_TMPDIR/aahp.config.json"
+}
+
 prepare_gate_baseline() {
     create_full_handoff
     git -C "$TEST_TMPDIR" add -A
@@ -84,10 +97,8 @@ commit_reviewed_file() {
 }
 
 @test "Python fallback also rejects duplicate JSON keys" {
-    local fallback_lib="$TEST_TMPDIR/fallback-lib.sh"
-    cp "$SCRIPTS_DIR/_aahp-lib.sh" "$fallback_lib"
-    sed '0,/if command -v node .*then/s//if false; then/' "$fallback_lib" > "$fallback_lib.tmp"
-    mv "$fallback_lib.tmp" "$fallback_lib"
+    local fallback_lib
+    fallback_lib="$(make_python_fallback_lib)"
     printf '%s\n' '{"handoffImpact":{"nonImpactingModifiedFiles":[]},"handoffImpact":{"nonImpactingModifiedFiles":[]}}' \
         > "$TEST_TMPDIR/aahp.config.json"
 
@@ -95,6 +106,29 @@ commit_reviewed_file() {
         "$fallback_lib" "$TEST_TMPDIR/aahp.config.json"
     [ "$status" -ne 0 ]
     [[ "$output" == *"duplicate JSON object key: handoffImpact"* ]]
+}
+
+@test "Node and Python parsers reject non-standard constants and invisible reasons" {
+    local fallback_lib value
+    fallback_lib="$(make_python_fallback_lib)"
+    local cases=(
+        '{"handoffImpact":NaN}'
+        '{"handoffImpact":Infinity}'
+        '{"handoffImpact":-Infinity}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"\u200B"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"reviewed \u202E rationale"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"\uFEFF"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"..."}]}}'
+    )
+    for value in "${cases[@]}"; do
+        printf '%s\n' "$value" > "$TEST_TMPDIR/aahp.config.json"
+
+        run parse_impact_config
+        [ "$status" -ne 0 ] || { echo "Node accepted invalid policy: $value"; false; }
+
+        run parse_impact_config_with_lib "$fallback_lib"
+        [ "$status" -ne 0 ] || { echo "Python accepted invalid policy: $value"; false; }
+    done
 }
 
 @test "absent handoffImpact config preserves the original impacting behavior" {
@@ -270,6 +304,78 @@ commit_reviewed_file() {
     [[ "$output" == *"base resolves to HEAD"* ]]
 }
 
+@test "an explicit empty base is rejected instead of using the local fallback" {
+    prepare_gate_baseline
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--base requires a non-empty commit SHA"* ]]
+    [[ "$output" != *"aahp verify passed"* ]]
+}
+
+@test "a symlinked config cannot supply Layer 2 policy" {
+    prepare_gate_baseline
+    mkdir -p "$TEST_TMPDIR/docs"
+    printf 'baseline\n' > "$TEST_TMPDIR/docs/sensitive.md"
+    printf '%s\n' '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/sensitive.md","reason":"Policy reached through a symlink."}]}}' \
+        > "$TEST_TMPDIR/policy.json"
+    ln -s policy.json "$TEST_TMPDIR/aahp.config.json"
+    [ -L "$TEST_TMPDIR/aahp.config.json" ] || skip "requires filesystem symlink support"
+    git -C "$TEST_TMPDIR" add docs/sensitive.md policy.json aahp.config.json
+    git -C "$TEST_TMPDIR" commit -q -m "track a symlinked policy"
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/sensitive.md"
+    git -C "$TEST_TMPDIR" add docs/sensitive.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"aahp.config.json is not a regular tracked file (mode 120000)"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+}
+
+@test "reviewed modifications reject mode-only and content-plus-mode changes" {
+    prepare_gate_baseline
+    commit_reviewed_file "docs/maintenance.md"
+    git -C "$TEST_TMPDIR" update-index --chmod=+x docs/maintenance.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"changed Git mode: docs/maintenance.md (100644 -> 100755)"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+
+    git -C "$TEST_TMPDIR" reset -q HEAD -- docs/maintenance.md
+    git -C "$TEST_TMPDIR" checkout -q -- docs/maintenance.md
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/maintenance.md"
+    git -C "$TEST_TMPDIR" add docs/maintenance.md
+    git -C "$TEST_TMPDIR" update-index --chmod=+x docs/maintenance.md
+
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"changed Git mode: docs/maintenance.md (100644 -> 100755)"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+}
+
+@test "CI compares reviewed file modes across the base and HEAD endpoints" {
+    prepare_gate_baseline
+    commit_reviewed_file "docs/maintenance.md"
+    local base
+    base="$(git -C "$TEST_TMPDIR" rev-parse HEAD)"
+
+    git -C "$TEST_TMPDIR" update-index --chmod=+x docs/maintenance.md
+    git -C "$TEST_TMPDIR" commit -q -m "mode-only change"
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$base"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"changed Git mode: docs/maintenance.md (100644 -> 100755)"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+
+    printf 'modified\n' >> "$TEST_TMPDIR/docs/maintenance.md"
+    git -C "$TEST_TMPDIR" add docs/maintenance.md
+    git -C "$TEST_TMPDIR" commit -q -m "content plus mode change"
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$base"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"changed Git mode: docs/maintenance.md (100644 -> 100755)"* ]]
+    [[ "$output" != *"Reviewed non-impacting modification"* ]]
+}
+
 @test "AAHP_BASE_SHA supplies a valid non-vacuous CI base" {
     prepare_gate_baseline
     AAHP_BASE_SHA="$CI_BASE" run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
@@ -382,6 +488,10 @@ try {
         '{"handoffImpact":{"nonImpactingModifiedFiles":{}}}'
         '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md"}]}}'
         '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"   "}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"\u200B"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"reviewed \u202E rationale"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"\uFEFF"}]}}'
+        '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/a.md","reason":"..."}]}}'
         '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"/tmp/a","reason":"x"}]}}'
         '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"../a","reason":"x"}]}}'
         '{"handoffImpact":{"nonImpactingModifiedFiles":[{"file":"docs/*.md","reason":"x"}]}}'

--- a/tests/handoff-impact.bats
+++ b/tests/handoff-impact.bats
@@ -369,6 +369,7 @@ commit_reviewed_file() {
 
     printf 'modified\n' >> "$TEST_TMPDIR/docs/maintenance.md"
     git -C "$TEST_TMPDIR" add docs/maintenance.md
+    git -C "$TEST_TMPDIR" update-index --chmod=+x docs/maintenance.md
     git -C "$TEST_TMPDIR" commit -q -m "content plus mode change"
     run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$base"
     [ "$status" -eq 1 ]

--- a/tests/propagate.bats
+++ b/tests/propagate.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+# propagate.bats - The fail-closed gate and its parser travel together.
+
+setup() {
+    load test_helper
+    setup
+    create_full_handoff
+    git -C "$TEST_TMPDIR" add -A
+    git -C "$TEST_TMPDIR" commit -q -m "seed handoff"
+}
+
+teardown() {
+    teardown
+}
+
+@test "propagation copies the parser and explicit-base workflow together" {
+    run bash "$AAHP_ROOT/scripts/propagate.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    grep -q 'aahp_non_impacting_modified_files' "$TEST_TMPDIR/scripts/_aahp-lib.sh"
+    grep -q 'AAHP_BASE_SHA.*pull_request.base.sha.*event.before.*inputs.base' \
+        "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
+    ! grep -Eqi 'dependabot|author\.username|github\.actor' \
+        "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
+}

--- a/tests/propagate.bats
+++ b/tests/propagate.bats
@@ -21,4 +21,33 @@ teardown() {
         "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
     ! grep -Eqi 'dependabot|author\.username|github\.actor' \
         "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
+    cmp "$AAHP_ROOT/scripts/verify-handoff.sh" "$TEST_TMPDIR/scripts/verify-handoff.sh"
+    cmp "$AAHP_ROOT/scripts/_aahp-lib.sh" "$TEST_TMPDIR/scripts/_aahp-lib.sh"
+    cmp "$AAHP_ROOT/.github/workflows/aahp-verify.yml" \
+        "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
+}
+
+@test "the packed npm artifact propagates byte-identical gate files and workflow" {
+    local pack_dir install_dir tarball installed_root
+    pack_dir="$TEST_TMPDIR/pack"
+    install_dir="$TEST_TMPDIR/install"
+    mkdir -p "$pack_dir" "$install_dir"
+
+    run npm pack "$AAHP_ROOT" --silent --pack-destination "$pack_dir"
+    [ "$status" -eq 0 ]
+    tarball="$pack_dir/$(printf '%s\n' "$output" | tail -1)"
+    [ -f "$tarball" ]
+
+    run npm install --silent --ignore-scripts --no-audit --no-fund --no-package-lock \
+        --prefix "$install_dir" "$tarball"
+    [ "$status" -eq 0 ]
+    installed_root="$install_dir/node_modules/@elvatis_com/aahp"
+    [ -f "$installed_root/.github/workflows/aahp-verify.yml" ]
+
+    run bash "$installed_root/scripts/propagate.sh" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    cmp "$AAHP_ROOT/scripts/verify-handoff.sh" "$TEST_TMPDIR/scripts/verify-handoff.sh"
+    cmp "$AAHP_ROOT/scripts/_aahp-lib.sh" "$TEST_TMPDIR/scripts/_aahp-lib.sh"
+    cmp "$AAHP_ROOT/.github/workflows/aahp-verify.yml" \
+        "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,13 +26,13 @@ if [ $# -gt 0 ]; then
     # Run a specific test suite
     suite="$1"
     case "$suite" in
-        manifest|lint|migrate|migrate-grounding|archive|verify|cli|gates|doctor|anti-entropy|check|init-gates|gates-portability|nonnpm-root|acceptance-criteria)
+        manifest|lint|migrate|migrate-grounding|archive|verify|handoff-impact|propagate|cli|gates|doctor|anti-entropy|check|init-gates|gates-portability|nonnpm-root|acceptance-criteria)
             echo "Running $suite tests..."
             $BATS "$SCRIPT_DIR/${suite}.bats"
             ;;
         *)
             echo "Unknown suite: $suite" >&2
-            echo "Available: manifest, lint, migrate, migrate-grounding, archive, verify, cli, gates, doctor, anti-entropy, check, init-gates, gates-portability, nonnpm-root, acceptance-criteria" >&2
+            echo "Available: manifest, lint, migrate, migrate-grounding, archive, verify, handoff-impact, propagate, cli, gates, doctor, anti-entropy, check, init-gates, gates-portability, nonnpm-root, acceptance-criteria" >&2
             exit 1
             ;;
     esac

--- a/tests/verify.bats
+++ b/tests/verify.bats
@@ -23,6 +23,7 @@ EOF
     bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet --phase implementation
     git -C "$TEST_TMPDIR" add -A
     git -C "$TEST_TMPDIR" commit -q -m "manifest"
+    CI_BASE="$(git -C "$TEST_TMPDIR" rev-parse HEAD~1)"
 }
 
 teardown() {
@@ -50,7 +51,7 @@ teardown() {
 
     run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Code changed but handoff state did not. Run /handoff."* ]]
+    [[ "$output" == *"Handoff-impacting files changed but handoff state did not. Run /handoff."* ]]
 }
 
 @test "drift gate PASSES when code + STATUS.md + MANIFEST.json change together" {
@@ -61,7 +62,7 @@ teardown() {
 
     run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
     [ "$status" -eq 0 ]
-    [[ "$output" == *"handoff state (STATUS.md + MANIFEST.json) changed with it"* ]]
+    [[ "$output" == *"Handoff-impacting files changed and handoff state (STATUS.md + MANIFEST.json) changed with them"* ]]
 }
 
 @test "drift gate FAILS when code + MANIFEST change but STATUS.md does not" {
@@ -102,9 +103,9 @@ teardown() {
     echo "console.log('x')" > "$TEST_TMPDIR/feature.js"
     git -C "$TEST_TMPDIR" add feature.js
 
-    AAHP_SKIP_VERIFY=1 run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    AAHP_SKIP_VERIFY=1 run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Code changed but handoff state did not"* ]]
+    [[ "$output" == *"Handoff-impacting files changed but handoff state did not"* ]]
 }
 
 # ─── Layer 1: checksum integrity ─────────────────────────────
@@ -123,7 +124,7 @@ teardown() {
     git -C "$TEST_TMPDIR" add -A
     git -C "$TEST_TMPDIR" commit -q -m "delete an indexed handoff file"
 
-    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"Missing indexed file: LOG.md"* ]]
     [[ "$output" == *"indexes file(s) that are not present"* ]]
@@ -156,7 +157,7 @@ STUB
     # Real tampering, not a stubbed message.
     printf '\nunmanaged edit\n' >> "$TEST_TMPDIR/.ai/handoff/STATUS.md"
 
-    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"checksums do not match"* ]]
     [[ "$output" == *"Checksum mismatch: STATUS.md"* ]]
@@ -167,7 +168,7 @@ STUB
     stub="$(_stub_scripts_dir_with_silent_passing_lint)"
     rm "$TEST_TMPDIR/.ai/handoff/NEXT_ACTIONS.md"
 
-    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"Missing indexed file: NEXT_ACTIONS.md"* ]]
 }
@@ -183,7 +184,7 @@ STUB
     cp -r "$SCRIPTS_DIR" "$stub"
     printf '\nunset -f aahp_manifest_index\n' >> "$stub/_aahp-lib.sh"
 
-    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"aahp_manifest_index"* ]]
     [[ "$output" == *"out of date"* ]]
@@ -198,7 +199,7 @@ STUB
     cp -r "$SCRIPTS_DIR" "$stub"
     printf '\naahp_manifest_index() { return 2; }\n' >> "$stub/_aahp-lib.sh"
 
-    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"No JSON interpreter available"* ]]
     [[ "$output" != *"aahp verify passed"* ]]
@@ -216,7 +217,7 @@ manifest["files"] = {}
 json.dump(manifest, open(path, "w", encoding="utf-8"), indent=2)
 PY
 
-    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"indexes no files"* ]]
     [[ "$output" != *"aahp verify passed"* ]]
@@ -242,7 +243,7 @@ PY
     git -C "$TEST_TMPDIR" add -A
     git -C "$TEST_TMPDIR" commit -q -m "drop one entry from the index"
 
-    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 1 ]
     [[ "$output" == *"Unindexed handoff file: LOG.md"* ]]
     [[ "$output" == *"present on disk but NOT indexed"* ]]
@@ -273,7 +274,7 @@ for name, meta in (m.get("files") or {}).items():
 }
 LIBSTUB
 
-    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci
+    run bash "$stub/verify-handoff.sh" "$TEST_TMPDIR" --level ci --base "$CI_BASE"
     [ "$status" -eq 0 ]
     [[ "$output" != *"checksums do not match"* ]]
 }


### PR DESCRIPTION
## Summary

- anchor Layer 2 to an explicit event base and compare endpoint trees so rollback and force-push changes cannot produce a vacuous green diff
- replace the actor-wide workflow exemption with reviewed, exact, regular-file content-only impact classifications
- fail closed on empty or invalid bases, config symlinks, non-regular Git modes, executable-bit changes, malformed policy, parser divergence, and git diff failures
- include the canonical verify workflow in the npm artifact and prove installed-package propagation copies the gate, parser, and workflow byte-for-byte
- document that a pull-request workflow is self-authorizing unless repository rules protect its evaluator paths or an operator supplies a default-branch evaluator
- prepare the additive v3.10.0 schema, specification, rollout, changelog, CLI help, and handoff surfaces without tagging or publishing

## Verification

Focused Windows/Git Bash validation was limited to the files covering the change; hosted Linux CI ran the repository suite.

- exact head `dcee9e74c0088421a186563f499ca59f258be65f`: all Linux checks green
- Linux `lint-and-validate`: pass, including shellcheck, release gates, doctor, schema validation, and the full Bats suite
- Linux `aahp-verify`, lint, manifest, archive, PII allowlist, and CodeQL: pass
- local `tests/handoff-impact.bats`: 24 pass, 3 Windows platform/dependency skips; the skipped schema cases passed separately with existing local schema dependencies
- local `tests/propagate.bats`: 2/2, including local npm pack/install and byte-equality checks
- local `tests/verify.bats`: 22/22 from the feature implementation
- local `npm run check`, `npm run doctor`, and staged `aahp verify --level precommit`: pass
- the first replacement head exposed a cross-platform fixture flaw: Linux `git add` correctly restored mode 100644 after a content edit; the final fixture explicitly reapplies 100755 and the exact-head Linux rerun is green

## Acceptance criteria

- [x] CI requires an explicit non-empty, non-zero, readable base and fails on HEAD-equal bases or any diff error.
- [x] Endpoint-tree comparison keeps rollback and force-push changes visible.
- [x] Only an exact content-only modification with equal old/new regular-file modes and a visible review reason can be classified non-impacting.
- [x] The policy file must itself be a regular tracked Git object; a symlink cannot delegate policy to a mutable referent.
- [x] A/D/R/C, mode changes, mixed source changes, untracked or unstaged policy, duplicate keys, symlinks, and gitlinks remain blocking.
- [x] Node, Python, and schema validation reject non-standard numeric constants, invisible rationales, and Unicode control or format characters consistently.
- [x] The packed npm artifact can propagate byte-identical gate, parser, and workflow files.
- [x] Documentation states the pull-request evaluator trust boundary and the required trusted-review/default-branch mitigation.
- [x] Layer 1 runs for every actor; the required workflow has least privilege and immutable action pins.
