### PR TITLE
fix(manifest): resolve project from repository identity, not from cwd

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,77 +2,77 @@
   "aahp_version": "3.0",
   "project": "AAHP",
   "last_session": {
-    "agent": "codex",
-    "session_id": "cli-1787268998",
-    "timestamp": "2026-08-20T23:36:39Z",
-    "commit": "c332a23",
+    "agent": "cli-tool",
+    "session_id": "cli-1787338022",
+    "timestamp": "2026-08-21T18:47:02Z",
+    "commit": "fed5b9f",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:218922e1a3daea578a2d46c65f1b17e22b3b34b25a8c5a5409f61d462020e822",
-      "updated": "2026-08-20T23:36:27Z",
-      "lines": 85,
+      "checksum": "sha256:07955e8d1a3d0c2160e4b785fd629fe707ba1d3e9d93d5f0d91e68028d5e247d",
+      "updated": "2026-08-21T18:47:02Z",
+      "lines": 87,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:efdc6ef8664faf9ce5120fa797b702d2353bd4c3205c62e5ba651a465326103d",
-      "updated": "2026-08-20T22:10:19Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 239,
       "summary": "Current version: **v3.10.0**"
     },
     "LOG.md": {
       "checksum": "sha256:b6296369cedefd0c52a00e8ed2662ad839e238e8162d93c0fda76547e30c0bce",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 250,
       "summary": "**Agent:** claude-opus-5"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:952cebfc3ba42ba60c913defd9ca292d122a4151230b53e59b9201fd0dac5933",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 159,
       "summary": "**Agent:** Claude Opus 4.6"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:5cb8447453139052e528f8dfc67d88f3d5e74bb40e5fc1672aa55ca30980de98",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 29,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e96e392db8dab2e9719e542dfa2a10c240d0be16ac6721298c460a22985cbdea",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 96,
       "summary": "| Name | Path | Build | Tests | Status | Notes |"
     },
     "TRUST.md": {
       "checksum": "sha256:91f124fe10a934779ef1d7442dd54af6656bbc03c4b1cde13a9d4cac9ab248e6",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 93,
       "summary": "| Level | Meaning |"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:1c0150404d22c6e15e39139e8b2c991b0167ba1e095f579efafb85555dfe0d88",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 93,
       "summary": "The project motto (Asimov's Three Laws) and the **do no damage** principle live once, in README (## Our Motto: The Three Laws). Agents must never take"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:ef005f24e399791abb986b3a76403295c33ad3b28bb9b7dc777d1d0528b31151",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 156,
       "summary": "| Agent | Model | Role | Responsibility |"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 209,
       "summary": "This register EXTENDS existing AAHP machinery; it does not fork or replace it. It"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-20T21:21:47Z",
+      "updated": "2026-08-21T18:31:32Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3460,
-    "full_read": 13530
+    "manifest_plus_core": 3560,
+    "full_read": 13630
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,6 +1,6 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-08-21 by codex
+> Last updated: 2026-08-21 by claude (manifest project-name fix)
 > Commit: (review branch, pending commit)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
@@ -59,6 +59,7 @@ remains verify-only and never regenerates handoff state.
 | CLI | `bin/aahp.js` | Changed | verify help documents `--base SHA` |
 | Specification | `README.md` | Changed | Section 2.8 and ADR-018 define the contract |
 | Rollout | `scripts/ROLLOUT.md` | Changed | consumer propagation and mutation checks documented |
+| Manifest generator | `scripts/aahp-manifest.sh` | Changed | `project` resolves from repository identity (recorded name, then git remote), not from the directory it runs in |
 | Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, workflow included in npm artifact, not released |
 <!-- /SECTION: components -->
 
@@ -74,6 +75,7 @@ remains verify-only and never regenerates handoff state.
 | Evaluator path protection | HIGH | The supplied `pull_request` workflow executes proposed workflow and gate code. A consumer must require trusted review for evaluator paths or supply a default-branch evaluator; v3.10.0 cannot configure repository rules. |
 | Delete-both-sides Layer 1 hole | MEDIUM | Pre-existing: removing a canonical handoff file and its index entry still needs a required-set protocol decision. |
 | Windows CI runner | MEDIUM | Pre-existing: Git Bash behavior is locally focused-tested, but CI remains Linux-only. |
+| Consumer manifests already rewritten | MEDIUM | The generator no longer writes a checkout's directory name into `project`, but repositories whose committed `MANIFEST.json` already carries such a name keep it, because a recorded name is preserved by design. Those values need correcting in the consumer repositories. |
 <!-- /SECTION: what_is_missing -->
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ independently of the npm version).
 
 ## [Unreleased]
 
+### Fixed
+- `MANIFEST.json`'s `project` no longer takes the name of the directory the generator
+  ran in. It resolves the repository's identity instead: the name already on record in
+  `MANIFEST.json` first, then the git remote's repository name, and the directory
+  basename only for a genuinely new manifest in a repository with no remote. A
+  `git worktree` checkout is named after the branch and a CI workdir after the job, so
+  the old behaviour rewrote `project` to that name on every regeneration, silently,
+  unless somebody re-read the file afterwards. Two such names reached consumer main
+  branches.
+- An unsubstituted `[PROJECT]` placeholder, which `aahp init` copies in from
+  `templates/MANIFEST.json`, is no longer carried forward as though it were a chosen
+  name. It falls through to the remote-derived name.
+- The remote-derived name needs only `git`, so the project name is now correct where
+  `node` is absent (a stripped hook `PATH`, a slim CI image). That path previously fell
+  back to the directory basename with no diagnostic, because the warning about failing
+  to read the existing manifest sits inside the `command -v node` guard.
+- The `project` value is escaped for JSON on write, as the quick context already was, so
+  a quote or backslash in a preserved name or a directory basename cannot emit a
+  `MANIFEST.json` that no longer parses.
+
 ## [3.10.0] - 2026-08-20
 **Fail-closed Layer 2 base selection and reviewed exact-file impact classification**
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,24 @@ itself. Repository rules must require trusted review for changes to the workflow
 provide a default-branch evaluator). v3.10.0 does not ship that repository-specific
 review/ruleset configuration. The
 workflow passes the pull request base SHA on pull requests and the event's
-`before` SHA on pushes. At `--level ci`, a missing, all-zero, unreadable,
+`before` SHA on pushes. A `workflow_dispatch` run carries neither, so that
+trigger MUST also declare a required `base` input and the step MUST fall back
+to it; the shipped workflow does both, and a copy that drops either half turns
+every manual run into a blocking failure:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      base:
+        description: Exact base commit SHA for the Layer 2 diff
+        required: true
+        type: string
+# ...
+        env:
+          AAHP_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || inputs.base }}
+```
+ At `--level ci`, a missing, all-zero, unreadable,
 invalid, or HEAD-equal base and every failed git diff are blocking failures.
 `AAHP_BASE_SHA` is the environment equivalent of `--base`. The gate compares
 the base and HEAD endpoint trees, rather than a merge-base three-dot range, so

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -76,7 +76,60 @@ esac
 
 # ─── Detect project metadata ─────────────────────────────────
 
-PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+# The project name must come from the repository's IDENTITY, never from the
+# directory the generator happens to run in. Agents work in `git worktree`
+# checkouts whose directory is named after the BRANCH, and CI unpacks into a
+# workdir named after the job, so a cwd-derived name silently rewrites
+# "project" to something like "myrepo-some-branch" and that lands on main.
+# It is invisible unless somebody re-reads the file after regenerating.
+# Resolution order, strongest evidence first:
+#
+#   1. the "project" already on record in MANIFEST.json (applied further down,
+#      once that file has been read) - a name a human set always wins;
+#   2. the git remote's repository name - stable across worktrees, temp dirs,
+#      CI workdirs and tarballs, and available without node;
+#   3. the directory basename - only for a genuinely new manifest in a repo
+#      with no remote, which is the original behaviour.
+
+# A recorded name is usable if it is non-empty and is not the placeholder that
+# `aahp init` copies in from templates/MANIFEST.json. "[PROJECT]" on record
+# means nobody ever substituted a name, so it must not suppress steps 2 and 3.
+aahp_project_name_usable() {
+    case "$1" in
+        ''|'[PROJECT]') return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Repository name from the remote URL. Handles https, scp-style
+# (host:org/repo), ssh:// and local-path remotes, with or without a .git suffix
+# or a trailing slash. Only the last path segment is kept, so any credentials
+# embedded in the URL are discarded with the rest of it and cannot reach
+# MANIFEST.json. The result must still look like a repository name; anything
+# else is rejected rather than interpolated into the JSON written below.
+aahp_project_from_remote() {
+    local root="$1" remote url name
+    if git -C "$root" remote get-url origin >/dev/null 2>&1; then
+        remote=origin
+    else
+        remote=$(git -C "$root" remote 2>/dev/null | head -n 1)
+    fi
+    [ -n "$remote" ] || return 1
+    url=$(git -C "$root" remote get-url "$remote" 2>/dev/null) || return 1
+    name="${url%/}"       # drop a trailing slash
+    name="${name##*/}"    # keep the last path segment
+    name="${name##*:}"    # scp-style remote with no slash after the colon
+    name="${name%.git}"   # drop the .git suffix
+    case "$name" in
+        ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    esac
+    printf '%s' "$name"
+}
+
+PROJECT_ABS=$(cd "$PROJECT_ROOT" && pwd)
+if ! PROJECT_NAME=$(aahp_project_from_remote "$PROJECT_ABS"); then
+    PROJECT_NAME=$(basename "$PROJECT_ABS")
+fi
 COMMIT=$(cd "$PROJECT_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -187,12 +240,14 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
             if [ -n "$EXISTING_CRR" ]; then
                 CROSS_REPO_REF="$EXISTING_CRR"
             fi
-            if [ -n "$EXISTING_PROJECT" ]; then
+            if aahp_project_name_usable "$EXISTING_PROJECT"; then
                 # Preserve the project name already on record instead of
-                # re-deriving it from the directory basename: regenerating
-                # inside a differently-named checkout (a temp dir, a CI
-                # workdir, a tarball) must not overwrite a consumer's real
-                # project name with that checkout's basename.
+                # re-deriving it: regenerating inside a differently-named
+                # checkout (a worktree, a temp dir, a CI workdir, a tarball)
+                # must not overwrite a consumer's real project name. An
+                # unsubstituted "[PROJECT]" placeholder is not a name that
+                # anybody chose, so it falls through to the remote-derived
+                # value resolved above instead of being carried forward.
                 PROJECT_NAME="$EXISTING_PROJECT"
             fi
         else
@@ -204,6 +259,14 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
 fi
 
 # ─── Write MANIFEST.json ─────────────────────────────────────
+
+# Escape the project name the same way the quick context is escaped above. The
+# remote-derived name is already restricted to safe characters, but a preserved
+# name and a directory basename are not: an unescaped quote or backslash in
+# either would emit a MANIFEST.json that no longer parses, which then fails the
+# integrity layer for a reason that points nowhere near the real cause.
+PROJECT_NAME=${PROJECT_NAME//\\/\\\\}
+PROJECT_NAME=${PROJECT_NAME//\"/\\\"}
 
 {
     cat <<MANIFEST

--- a/tests/manifest.bats
+++ b/tests/manifest.bats
@@ -349,27 +349,48 @@ _detect_python() {
     # the warning lives inside the `command -v node` guard. Before the remote
     # fallback existed, the name then became the directory basename with no
     # diagnostic at all. git alone is enough to get it right.
-    # Drop only the directory node lives in, rather than building a shim
-    # directory: a shim needs copies or symlinks of bash and git, which is not
-    # portable to Windows, and a test that can only ever skip proves nothing.
-    node_dir="$(dirname "$(command -v node)")"
-    stripped_path="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vxF "$node_dir" | paste -sd: -)"
+    # Drop EVERY PATH entry that holds a node executable, rather than building
+    # a shim directory of symlinked binaries. A shim needs copies of bash and
+    # git, which is not portable to Windows, and a test that can only ever
+    # `skip` proves nothing. Dropping only the first such entry is not enough
+    # either: a CI runner commonly has two node installs (a system one and a
+    # toolcache one), and stripping one leaves the branch untested while the
+    # test still reports on it.
+    stripped_path=""
+    saved_ifs="$IFS"
+    set -f
+    IFS=':'
+    for entry in $PATH; do
+        if [ -z "$entry" ]; then continue; fi
+        if [ -x "$entry/node" ] || [ -x "$entry/node.exe" ]; then continue; fi
+        stripped_path="${stripped_path}${stripped_path:+:}$entry"
+    done
+    IFS="$saved_ifs"
+    set +f
 
-    # Guard the isolation itself. If node were still reachable, or bash/git
-    # were not, this test would report green without exercising the path it
-    # names. Fail rather than skip: on every platform this suite runs on,
-    # node is installed somewhere other than the directory holding bash.
-    PATH="$stripped_path" command -v git >/dev/null 2>&1
-    PATH="$stripped_path" command -v bash >/dev/null 2>&1
-    ! PATH="$stripped_path" command -v node >/dev/null 2>&1
+    # Assert the CONSEQUENCE of the isolation, not its configuration: node must
+    # actually fail to EXECUTE under this PATH, and git and bash must actually
+    # run. `env` performs a real execvp, so unlike `command -v` it cannot be
+    # satisfied by a shell hash-table entry or by builtin lookup order. Failing
+    # here beats skipping: a test that cannot fire is indistinguishable from a
+    # passing one.
+    run env PATH="$stripped_path" node --version
+    [ "$status" -ne 0 ]
+    run env PATH="$stripped_path" git --version
+    [ "$status" -eq 0 ]
+    run env PATH="$stripped_path" bash -c 'exit 7'
+    [ "$status" -eq 7 ]
 
     dir_name="$(basename "$TEST_TMPDIR")"
     run env PATH="$stripped_path" bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
     [ "$status" -eq 0 ]
 
-    manifest_content=$(cat "$TEST_TMPDIR/.ai/handoff/MANIFEST.json")
-    [[ "$manifest_content" == *'"project": "aahp-consumer"'* ]]
-    [[ "$manifest_content" != *"\"project\": \"$dir_name\""* ]]
+    # Read the value back explicitly so a regression reports the name that was
+    # actually written instead of only that a glob did not match.
+    run sed -n 's/.*"project": "\([^"]*\)".*/\1/p' "$TEST_TMPDIR/.ai/handoff/MANIFEST.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "aahp-consumer" ]
+    [ "$output" != "$dir_name" ]
 }
 
 # ─── File indexing ───────────────────────────────────────────

--- a/tests/manifest.bats
+++ b/tests/manifest.bats
@@ -230,8 +230,12 @@ _detect_python() {
     create_status_md
     create_next_actions_md
     create_log_md
-    # No existing MANIFEST.json: this is a first-ever generation, so the
-    # project name must come from the directory basename.
+    # No existing MANIFEST.json AND no git remote: nothing else carries the
+    # repository's identity, so the directory basename is the only source left
+    # and the original behaviour must be preserved. The precondition is
+    # asserted, otherwise a remote appearing in the fixture later would make
+    # this test pass for the wrong reason.
+    [ -z "$(git -C "$TEST_TMPDIR" remote)" ]
 
     run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
     [ "$status" -eq 0 ]
@@ -239,6 +243,133 @@ _detect_python() {
     manifest_content=$(cat "$TEST_TMPDIR/.ai/handoff/MANIFEST.json")
     expected_name="$(basename "$TEST_TMPDIR")"
     [[ "$manifest_content" == *"\"project\": \"$expected_name\""* ]]
+}
+
+# ─── Project name comes from repository identity, not from cwd ───
+#
+# Every agent in this estate works in a `git worktree` whose directory is named
+# after the BRANCH, and CI unpacks into a workdir named after the job. A
+# cwd-derived project name therefore rewrites MANIFEST.json's "project" to the
+# checkout's name on every regeneration, and the rewrite is invisible unless
+# somebody re-reads the file afterwards. Two such values reached consumer main
+# branches before this was fixed. Each test below runs the generator from a
+# directory whose name is NOT the repository name.
+
+@test "derives project name from the git remote, not the directory it runs in" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    # First generation (no MANIFEST.json), so the recorded-name path cannot be
+    # what rescues this: the remote is the only thing naming the repository.
+    git -C "$TEST_TMPDIR" remote add origin https://github.com/homeofe/aahp-consumer.git
+
+    run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+
+    # Guard: the directory really is named something else, so the assertions
+    # below discriminate instead of being accidentally true.
+    dir_name="$(basename "$TEST_TMPDIR")"
+    [ "$dir_name" != "aahp-consumer" ]
+
+    manifest_content=$(cat "$TEST_TMPDIR/.ai/handoff/MANIFEST.json")
+    [[ "$manifest_content" == *'"project": "aahp-consumer"'* ]]
+    [[ "$manifest_content" != *"\"project\": \"$dir_name\""* ]]
+}
+
+@test "derives project name from an scp-style remote URL" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    git -C "$TEST_TMPDIR" remote add origin git@github.com:homeofe/aahp-consumer.git
+
+    run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+
+    dir_name="$(basename "$TEST_TMPDIR")"
+    [ "$dir_name" != "aahp-consumer" ]
+
+    manifest_content=$(cat "$TEST_TMPDIR/.ai/handoff/MANIFEST.json")
+    [[ "$manifest_content" == *'"project": "aahp-consumer"'* ]]
+    [[ "$manifest_content" != *"\"project\": \"$dir_name\""* ]]
+}
+
+@test "an unsubstituted [PROJECT] placeholder does not survive regeneration" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    create_manifest_json
+    git -C "$TEST_TMPDIR" remote add origin https://github.com/homeofe/aahp-consumer.git
+
+    # `aahp init` copies templates/MANIFEST.json in with "[PROJECT]" and tells
+    # the adopter to replace it. Until they do, that string is not a name
+    # anybody chose, so it must not outrank the repository's real identity.
+    manifest="$TEST_TMPDIR/.ai/handoff/MANIFEST.json"
+    sed 's/"project": "TestProject"/"project": "[PROJECT]"/' "$manifest" > "$manifest.tmp"
+    mv "$manifest.tmp" "$manifest"
+    # Guard the substitution: had it silently done nothing, the assertion below
+    # would pass via the ordinary preserve path and prove nothing.
+    grep -q '"project": "\[PROJECT\]"' "$manifest"
+
+    run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+
+    manifest_content=$(cat "$manifest")
+    [[ "$manifest_content" == *'"project": "aahp-consumer"'* ]]
+    [[ "$manifest_content" != *'"project": "[PROJECT]"'* ]]
+}
+
+@test "a recorded project name outranks the git remote" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    create_manifest_json
+    # A consumer whose handoff project name deliberately differs from the
+    # repository name must keep it. The remote is a fallback for when nothing
+    # is on record, never an override of a name a human set.
+    git -C "$TEST_TMPDIR" remote add origin https://github.com/homeofe/some-other-repo.git
+
+    run bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+
+    manifest_content=$(cat "$TEST_TMPDIR/.ai/handoff/MANIFEST.json")
+    [[ "$manifest_content" == *'"project": "TestProject"'* ]]
+    [[ "$manifest_content" != *'"project": "some-other-repo"'* ]]
+}
+
+@test "project name survives regeneration when node is unavailable" {
+    create_status_md
+    create_next_actions_md
+    create_log_md
+    create_manifest_json
+    git -C "$TEST_TMPDIR" remote add origin https://github.com/homeofe/aahp-consumer.git
+
+    # Reading the recorded name needs node to parse MANIFEST.json. Where node
+    # is missing (a stripped hook PATH, a slim CI image) that whole block is
+    # skipped SILENTLY - not even the "could not read" warning prints, because
+    # the warning lives inside the `command -v node` guard. Before the remote
+    # fallback existed, the name then became the directory basename with no
+    # diagnostic at all. git alone is enough to get it right.
+    # Drop only the directory node lives in, rather than building a shim
+    # directory: a shim needs copies or symlinks of bash and git, which is not
+    # portable to Windows, and a test that can only ever skip proves nothing.
+    node_dir="$(dirname "$(command -v node)")"
+    stripped_path="$(printf '%s' "$PATH" | tr ':' '\n' | grep -vxF "$node_dir" | paste -sd: -)"
+
+    # Guard the isolation itself. If node were still reachable, or bash/git
+    # were not, this test would report green without exercising the path it
+    # names. Fail rather than skip: on every platform this suite runs on,
+    # node is installed somewhere other than the directory holding bash.
+    PATH="$stripped_path" command -v git >/dev/null 2>&1
+    PATH="$stripped_path" command -v bash >/dev/null 2>&1
+    ! PATH="$stripped_path" command -v node >/dev/null 2>&1
+
+    dir_name="$(basename "$TEST_TMPDIR")"
+    run env PATH="$stripped_path" bash "$SCRIPTS_DIR/aahp-manifest.sh" "$TEST_TMPDIR" --quiet
+    [ "$status" -eq 0 ]
+
+    manifest_content=$(cat "$TEST_TMPDIR/.ai/handoff/MANIFEST.json")
+    [[ "$manifest_content" == *'"project": "aahp-consumer"'* ]]
+    [[ "$manifest_content" != *"\"project\": \"$dir_name\""* ]]
 }
 
 # ─── File indexing ───────────────────────────────────────────


### PR DESCRIPTION
## What was wrong

`scripts/aahp-manifest.sh` derived `MANIFEST.json`'s `project` from the basename of the
directory it ran in. Agents work in `git worktree` checkouts named after the **branch**, and
CI unpacks into a workdir named after the job, so every regeneration renamed the project to
that checkout. Nothing reports it, because the generator prints only a file count and a token
budget, so it is invisible unless somebody re-reads the file afterwards. Two such names reached
consumer `main` branches.

v3.9.1 (`fix(manifest): preserve MANIFEST project field on regeneration`,
https://github.com/homeofe/AAHP/pull/64) preserved a `project` already on record. That closed
the common case and is kept intact here, but three holes remained. All three were reproduced
against `main` before any code was changed:

| Path | `project` written on `main` | Now |
|------|------------------------------|-----|
| First generation, no `MANIFEST.json` | `elvatis-mcp-scg-pin` | `elvatis-mcp` |
| `[PROJECT]` placeholder on record | `[PROJECT]` | `elvatis-mcp` |
| `node` absent from `PATH` | `elvatis-mcp-scg-pin` | `elvatis-mcp` |

The `node` path is the worst of the three: reading the recorded name needs `node`, and the
entire block sits inside `if command -v node`. The `could not read the existing MANIFEST.json`
warning is inside that same guard, so where `node` is missing (a stripped hook `PATH`, a slim CI
image) the basename came back with **no diagnostic at all**.

## What changed

`project` now resolves from the repository's identity, strongest evidence first:

1. the name already on record in `MANIFEST.json`, unless it is empty or the unsubstituted
   `[PROJECT]` placeholder that `aahp init` copies in from `templates/MANIFEST.json`;
2. the git remote's repository name, which needs only `git` and is stable across worktrees,
   temp dirs, CI workdirs and tarballs;
3. the directory basename, only for a genuinely new manifest in a repository with no remote.
   That is the original behaviour and it is unchanged.

A recorded name still outranks the remote, so a consumer whose handoff project name
deliberately differs from its repository name keeps it. Only the last path segment of the
remote URL is kept, so credentials embedded in a remote cannot reach `MANIFEST.json`, and a
result that does not look like a repository name is rejected rather than interpolated into the
JSON. `project` is now escaped on write exactly as `quick_context` already was, so a quote or a
backslash in a preserved name or a directory basename cannot emit a `MANIFEST.json` that no
longer parses.

`README.md` also now shows the `workflow_dispatch` `base` input next to the `AAHP_BASE_SHA`
fallback. The prose described only the `pull_request` and `push` arms; the shipped workflow was
already complete, but agents kept independently rediscovering that a manual run needs the input
declared, which is a documentation defect rather than a wiring one.

## Verification

**Mutation proof.** The fix was committed first, then `scripts/aahp-manifest.sh` alone was
reverted to `origin/main` with the new tests left in place. The revert was guarded by a
`git diff --quiet` check so a no-op substitution could not produce a vacuous proof. Result:

```
ok     12 preserves existing project name on regeneration
ok     13 derives project name from directory basename on first generation
not ok 14 derives project name from the git remote, not the directory it runs in
not ok 15 derives project name from an scp-style remote URL
not ok 16 an unsubstituted [PROJECT] placeholder does not survive regeneration
ok     17 a recorded project name outranks the git remote
not ok 18 project name survives regeneration when node is unavailable
```

The four defect paths go red; 12, 13 and 17 stay green, so the new tests assert the specific
defect rather than merely detecting that something changed. Restoring the file returns all 26
to green.

Test 18 strips `node` from `PATH` rather than building a shim directory of symlinked binaries.
A shim needs copies of `bash` and `git`, which is not portable to Windows, and a test that can
only ever `skip` proves nothing. It executes on both platforms and asserts its own isolation
before running. The first version of that isolation was itself defective; see *CI outcome, and
one correction* below.

**Real consumer.** Verified against `elvatis/elvatis-mcp`, read-only: cloned into a directory
named `elvatis-mcp-node-eol` to mirror the shape of an observed bad value. That repository pins
`@elvatis_com/aahp` at `3.8.1`, which is what actually produced the defect there.

| Generator | `MANIFEST.json` | `project` written |
|-----------|-----------------|-------------------|
| v3.8.1 (what the consumer pins today) | present, `elvatis-mcp` | `elvatis-mcp-node-eol` |
| this branch | present | `elvatis-mcp` |
| this branch | removed (first generation) | `elvatis-mcp` |
| this branch | present, `node` off `PATH` | `elvatis-mcp` |

Field preservation was checked separately against `elvatis/elvatis-client-portal`'s real
manifest (the only surveyed consumer carrying `tasks` and `next_task_id`), regenerated from a
directory named `elvatis-client-portal-some-branch` behind an scp-style remote:
`project`, `tasks` (1) and `next_task_id` (13) all survive unchanged.

**Repository gates.** `npm run check` passes (changelog, changelog format, version sync,
claims, forbidden patterns, schema-doc sync, doc links, handoff generator). `shellcheck -S
warning` and `bash -n` are clean on the modified script. CRLF counts were asserted unchanged on
every file edited: the shell scripts and the bats file stay LF, `README.md`, `CHANGELOG.md` and
`STATUS.md` stay CRLF.

Per the estate rule the full bats suite was **not** run on this Windows machine; only
`tests/manifest.bats` was, and it is the file covering the change. The hosted Linux runner
produces the full-suite verdict.

## Acceptance criteria

- [x] `project` is derived from the repository's identity, never from the directory the
      generator runs in, for a first generation, for a `[PROJECT]` placeholder, and when `node`
      is unavailable.
- [x] A `project` name already on record still wins over the remote, so v3.9.1's behaviour does
      not regress.
- [x] A genuinely new manifest in a repository with no remote still takes the directory
      basename, and a test asserts that precondition rather than assuming it.
- [x] A test runs the generator from a directory whose name differs from the repository and
      fails if the defect returns; the mutation proof shows it going red without the fix and
      green with it.
- [x] Preserved `tasks`, `next_task_id` and `cross_repo_ref` are unaffected.
- [x] The fix is verified against a real consumer repository, read-only, and the pre-fix
      behaviour is reproduced there for comparison.
- [x] `project` cannot emit invalid JSON, and remote credentials cannot leak into the manifest.
- [x] The `workflow_dispatch` `base` input is documented alongside the `AAHP_BASE_SHA` fallback.

## Merge preconditions

Do not merge until the required checks on this pull request have concluded green on the hosted
Linux runner, in particular the full `bats` suite and `AAHP Verify`. A conflicting pull request
runs no CI at all, so a merge-status check is not a substitute for reading the concluded runs.
This branch was cut explicitly from `origin/main` at `fed5b9f`.

## For the owner, not shipped here

Repositories whose committed `MANIFEST.json` already carries a checkout-derived name keep it,
because a recorded name is preserved by design and this pull request cannot tell a wrong
recorded name from a deliberate one. Those values need correcting in the consumer repositories
themselves, which is outside this repository's write scope. The gap is recorded in
`.ai/handoff/STATUS.md` under *What is Missing*.

## CI outcome, and one correction

The first push went red on `lint-and-validate`: the new node-unavailable test failed on the
Linux runner while passing on Windows. **The production fix was not at fault.** Running the
generator under WSL Ubuntu 24.04, which has git 2.43 and no node at all, writes
`"project": "aahp-consumer"` from the remote, exit 0. The defect was in the test's isolation.

It stripped only the directory `dirname $(command -v node)` names. A CI runner commonly carries
two node installs, a system one and a toolcache one, so removing the first leaves node
executable and the branch untested while the test still reports on it. Reproduced in WSL with
two node stubs on `PATH`: after the old strip, `node --version` still runs.

The test now drops **every** `PATH` entry holding a node executable and asserts the isolation by
consequence rather than by configuration, attempting a real `execvp` of node, git and bash
through `env`. `env` cannot be satisfied by a shell hash-table entry or by builtin lookup order
the way `command -v` can. The project value is also read back with `sed` and compared as a
string, so a future regression reports the name that was actually written rather than only that
a glob missed.

All checks now pass, and the five new tests execute on Linux with no skip markers:

```
ok 299 derives project name from the git remote, not the directory it runs in
ok 300 derives project name from an scp-style remote URL
ok 301 an unsubstituted [PROJECT] placeholder does not survive regeneration
ok 302 a recorded project name outranks the git remote
ok 303 project name survives regeneration when node is unavailable
```

This is worth recording because it is the same failure class the repository already guards
against elsewhere: a check that reports on a path it never actually exercised.
