### PR TITLE
fix(doctor): report when the workflow that runs the gate can skip it

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,16 +3,16 @@
   "project": "AAHP",
   "last_session": {
     "agent": "cli-tool",
-    "session_id": "cli-1787359604",
-    "timestamp": "2026-08-22T00:46:44Z",
-    "commit": "3c4e9c5",
+    "session_id": "cli-1787361192",
+    "timestamp": "2026-08-22T01:13:12Z",
+    "commit": "d0ab343",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:7bdec2aa7f37cb4c00212d9599245f28a439d2882ee422ffdc98d1c056b793e6",
-      "updated": "2026-08-22T00:46:38Z",
+      "checksum": "sha256:2674083db546cda4f1398ac733678948cff0b54bf3ebcfbe63d49ff36420b8fb",
+      "updated": "2026-08-22T01:13:12Z",
       "lines": 118,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4540,
-    "full_read": 14610
+    "manifest_plus_core": 4552,
+    "full_read": 14622
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,76 +3,76 @@
   "project": "AAHP",
   "last_session": {
     "agent": "cli-tool",
-    "session_id": "cli-1787345973",
-    "timestamp": "2026-08-21T20:59:34Z",
-    "commit": "0425fc6",
-    "phase": "implementation",
+    "session_id": "cli-1787359604",
+    "timestamp": "2026-08-22T00:46:44Z",
+    "commit": "3c4e9c5",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:662d490d552f39fc65e3ce58d41d700ff26c24e25b0845c5141613702b791726",
-      "updated": "2026-08-21T20:59:05Z",
-      "lines": 102,
+      "checksum": "sha256:7bdec2aa7f37cb4c00212d9599245f28a439d2882ee422ffdc98d1c056b793e6",
+      "updated": "2026-08-22T00:46:38Z",
+      "lines": 118,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:efdc6ef8664faf9ce5120fa797b702d2353bd4c3205c62e5ba651a465326103d",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 239,
       "summary": "Current version: **v3.10.0**"
     },
     "LOG.md": {
       "checksum": "sha256:b6296369cedefd0c52a00e8ed2662ad839e238e8162d93c0fda76547e30c0bce",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 250,
       "summary": "**Agent:** claude-opus-5"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:952cebfc3ba42ba60c913defd9ca292d122a4151230b53e59b9201fd0dac5933",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 159,
       "summary": "**Agent:** Claude Opus 4.6"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:5cb8447453139052e528f8dfc67d88f3d5e74bb40e5fc1672aa55ca30980de98",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 29,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e96e392db8dab2e9719e542dfa2a10c240d0be16ac6721298c460a22985cbdea",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 96,
       "summary": "| Name | Path | Build | Tests | Status | Notes |"
     },
     "TRUST.md": {
       "checksum": "sha256:91f124fe10a934779ef1d7442dd54af6656bbc03c4b1cde13a9d4cac9ab248e6",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 93,
       "summary": "| Level | Meaning |"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:1c0150404d22c6e15e39139e8b2c991b0167ba1e095f579efafb85555dfe0d88",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 93,
       "summary": "The project motto (Asimov's Three Laws) and the **do no damage** principle live once, in README (## Our Motto: The Three Laws). Agents must never take"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:ef005f24e399791abb986b3a76403295c33ad3b28bb9b7dc777d1d0528b31151",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 156,
       "summary": "| Agent | Model | Role | Responsibility |"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 209,
       "summary": "This register EXTENDS existing AAHP machinery; it does not fork or replace it. It"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-21T20:29:58Z",
+      "updated": "2026-08-22T00:25:59Z",
       "lines": 4,
       "summary": "{"
     }
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4110,
-    "full_read": 14180
+    "manifest_plus_core": 4540,
+    "full_read": 14610
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,6 +1,6 @@
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-08-21 by claude (runtime support: engines >=22, CI on 22/24)
+> Last updated: 2026-08-22 by claude (verify-workflow gate: can the workflow that runs the gate skip it?)
 > Commit: (review branch, pending commit)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
@@ -32,6 +32,20 @@ dead pin, so every consumer inherited the claim on install. Nothing could go red
 about it: the pins were internally consistent, just uniformly dead. `engines.node` is
 now `>=22`, CI validates on 22 and 24, and `check:runtime-support` asserts the
 RELATION between the two so neither side can rot alone.
+
+On top of that, `aahp doctor` gains a **`verify-workflow`** gate: it audits the
+consumer's own `.github/workflows/` and reports whether the workflow that hosts the
+AAHP gate can SKIP it. A job-level or step-level `if:` around the gate leaves a
+required status check that keeps its name and reports success having evaluated
+nothing, so branch protection is satisfied by a verdict nobody produced, and Layer 1
+MANIFEST checksum integrity goes missing along with the Layer 2 drift gate. AAHP
+could not see this from inside itself: the workflow it ships is unconditional and
+`propagate.sh` copies it verbatim, so the weakening only ever exists downstream. The
+canonical workflow's last step runs `aahp doctor`, so a consumer that has weakened
+its gate now reports it on its own pull requests. It is asserted as a CONSEQUENCE
+("there exists an event on which this workflow concludes success without having run
+the gate at `--level ci`"), it fails closed on a shape it cannot classify, and it was
+measured against every consumer of this protocol before shipping.
 <!-- /SECTION: summary -->
 
 ---
@@ -47,6 +61,7 @@ RELATION between the two so neither side can rot alone.
 | `tests/verify.bats` | FOCUSED PASS | 22/22 under Git Bash with explicit CI bases |
 | schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
 | shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
+| `tests/verify-workflow.bats` | FOCUSED PASS | 20/20; both directions, plus parser parity against a real YAML parser on 15 workflow files |
 | `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, runtime support, and handoff freshness |
 | `tests/runtime-support.bats` | FOCUSED PASS | 16/16; the relation holds on this repo and each of nine mutations turns it red, including the emptied-matrix trap |
 | shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |
@@ -71,6 +86,7 @@ RELATION between the two so neither side can rot alone.
 | Manifest generator | `scripts/aahp-manifest.sh` | Changed | `project` resolves from repository identity (recorded name, then git remote), not from the directory it runs in |
 | Runtime-support gate | `scripts/check-runtime-support.mjs` | New | relation between CI pins and `engines.node`; one dated constant; exits 2 when it cannot evaluate |
 | Runtime matrix | `.github/workflows/ci.yml` | Changed | new `runtime-matrix` job on Node 22 and 24; `lint-and-validate` deliberately left unmatrixed so the required check keeps its literal name |
+| verify-workflow gate | `scripts/check-verify-workflow.mjs` | New | audits the consumer's workflows for a gate that can skip itself; zero runtime dependencies, so it carries its own block-YAML reader, held against a real parser by `tests/assert-workflow-parser-parity.mjs` |
 | Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, workflow included in npm artifact, not released; `engines.node` now `>=22`, `yaml` added as a devDependency |
 <!-- /SECTION: components -->
 
@@ -88,8 +104,8 @@ RELATION between the two so neither side can rot alone.
 | Windows CI runner | MEDIUM | Pre-existing: Git Bash behavior is locally focused-tested, but CI remains Linux-only. |
 | `runtime-matrix` not a required check | HIGH | The new job reports `Runtime matrix (22)` and `Runtime matrix (24)`. Until an owner adds them to branch protection they can go red without blocking a merge. The relation gate itself runs inside the required `lint-and-validate`, so the claim is still enforced. |
 | SemVer call for `engines.node` | NORMAL | Narrowing `>=18` to `>=22` is a support-surface reduction. Whether it ships inside 3.10.0 or forces 4.0.0 is an owner decision, not one this branch takes. |
-| `aahp-verify` skipped wholesale in five consumers | HIGH | ORIGINATED HERE. `458dbbd` (2026-06-30) added the Dependabot exemption to this repository's own reference workflow, gating Checkout and every gate step; it shipped that way in v3.6.0 and propagated. `#65` removed it here on 2026-08-21. Five consumers still run the old shape and report success having checked out nothing, so Layer 1 never runs either: `elvatis-security-platform`, `elvatis-intelligence`, `elvatis-defense`, `elvatis-client-portal`, `elvatis-sso`. Corrected already in `atlas`, `elvatis-trust`, `elvatis-awareness`. Only the owning repositories can re-propagate. |
-| No drift check between a consumer's propagated workflow and the installed package | HIGH | `aahp doctor` verifies the PINNED VERSION (`pinned-dep`) but never that `.github/workflows/aahp-verify.yml` on disk matches the one in the installed package, so a consumer can pin 3.10.0 and still run the v3.6.0 workflow. That is exactly how the five above went unnoticed. A drift gate must tolerate deliberate divergence (`elvatis-trust` legitimately customised its Dependabot path), so it needs a designed predicate, not a byte-compare. |
+| `aahp-verify` can skip itself in six consumers | HIGH | ORIGINATED HERE. `458dbbd` (2026-06-30) added the dependency-bot exemption to this repository's own reference workflow, gating Checkout and every gate step; it shipped that way in v3.6.0 and propagated. `#65` removed it here on 2026-08-21. MEASURED 2026-08-22 with the new `verify-workflow` gate, against every consumer: six report `bypassable`, three report `enforced`. Five report success having checked out nothing, so Layer 1 never runs either: `elvatis-security-platform`, `elvatis-intelligence`, `elvatis-defense`, `elvatis-client-portal`, `elvatis-sso`. A sixth, `elvatis-trust`, was previously recorded here as corrected and is only PARTLY so: its checkout is unconditional and a bot change does get a Layer 1 run, but `--level ci` is still gated on the author, so the same required check name means all four layers for one author and Layer 1 for another. Fully corrected in `atlas` and `elvatis-awareness`. Only the owning repositories can re-propagate; this branch cannot fix any of them. |
+| No drift check between a consumer's propagated workflow and the installed package | PARTLY CLOSED | `aahp doctor` still never compares `.github/workflows/aahp-verify.yml` on disk against the one in the installed package, so a consumer can pin 3.10.0 and run the v3.6.0 workflow. The designed predicate this row asked for now exists for the case that matters: `verify-workflow` asks whether the hosting workflow can skip the gate, which tolerates deliberate divergence (a consumer may restructure the file freely) while catching the divergence that voids the check. General byte-level drift, for example an older action pin or a dropped `fetch-depth: 0`, is still unmeasured. |
 | Consumer manifests already rewritten | MEDIUM | The generator no longer writes a checkout's directory name into `project`, but repositories whose committed `MANIFEST.json` already carries such a name keep it, because a recorded name is preserved by design. Those values need correcting in the consumer repositories. |
 <!-- /SECTION: what_is_missing -->
 

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -61,7 +61,7 @@ measured against every consumer of this protocol before shipping.
 | `tests/verify.bats` | FOCUSED PASS | 22/22 under Git Bash with explicit CI bases |
 | schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
 | shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
-| `tests/verify-workflow.bats` | FOCUSED PASS | 20/20; both directions, plus parser parity against a real YAML parser on 15 workflow files |
+| `tests/verify-workflow.bats` | FOCUSED PASS | 21/21; both directions, the two fail-closed shapes that must NOT be findings, plus parser parity against a real YAML parser on 16 workflow files |
 | `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, runtime support, and handoff freshness |
 | `tests/runtime-support.bats` | FOCUSED PASS | 16/16; the relation holds on this repo and each of nine mutations turns it red, including the emptied-matrix trap |
 | shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ independently of the npm version).
 ## [Unreleased]
 
 ### Added
+- `aahp doctor` gains a `verify-workflow` gate that answers, from inside a consumer,
+  whether the workflow hosting the AAHP gate can skip it. Wrapping the `aahp-verify`
+  job in an `if:`, or wrapping the gate step inside it, leaves a REQUIRED status check
+  that keeps its name and reports success having evaluated nothing: Layer 1 MANIFEST
+  checksum integrity is skipped along with the Layer 2 drift gate, and branch
+  protection is satisfied by a verdict nobody produced. AAHP could not see this
+  before, because the workflow it ships and `propagate.sh` copies is unconditional,
+  so the weakening only ever exists in the consumer's copy. Since the canonical
+  workflow's last step runs `aahp doctor`, a repository that has weakened its gate
+  now reports it on its own pull requests.
+  What is asserted is the consequence ("there exists an event on which this workflow
+  concludes success without having run the gate at `--level ci`"), not the file's
+  shape. Five findings cover it: `job-conditional`, `job-soft-failing`,
+  `ci-step-conditional`, `ci-step-soft-failing` and `no-ci-level`. A repository whose
+  workflows never run the gate reports `skip`; one whose workflow hosts the gate but
+  cannot be classified reports `fail`, because undecided is not clean. Two shapes are
+  deliberately not findings because they fail CLOSED, not green: an `if:` on the
+  checkout step alone, and `paths:` filters that stop the workflow triggering.
+  The gate ships no YAML dependency, because AAHP has no runtime dependencies, so
+  `tests/assert-workflow-parser-parity.mjs` holds its block-YAML reader against a real
+  parser on every workflow and fixture in this repository, on the fields the audit
+  reads and on the resulting findings.
 - `npm run check:runtime-support` asserts that the runtimes CI exercises and the
   runtimes `engines.node` publishes are the same set, and that the floor of that set
   still receives security patches. It is a RELATION rather than a list of dead

--- a/README.md
+++ b/README.md
@@ -539,19 +539,72 @@ aahp doctor --json       # only the JSON record, on stdout
 aahp doctor --governance # governance-only record; skip the 3 handoff gates (alias --no-handoff)
 ```
 
-It checks six gates: the handoff file set matches `AAHP_HANDOFF_FILES` (indexed
+It checks seven gates: the handoff file set matches `AAHP_HANDOFF_FILES` (indexed
 files present, no strays); `MANIFEST.json` conforms to the schema; `GROUNDING.md`
 is present and `TRUST.md` carries a Provenance column; `@elvatis_com/aahp` is
 pinned to an exact version in `devDependencies` (`self` for this repo); the
-`CHANGELOG.md` matches the Keep a Changelog grammar; and the version is in sync
-across configured sites. The record:
+`CHANGELOG.md` matches the Keep a Changelog grammar; the version is in sync
+across configured sites; and the workflow that runs the AAHP gate cannot skip it
+(`verify-workflow`, below). The record:
 
 ```json
 { "schemaVersion": 1, "repo": "homeofe/AAHP", "aahpVersion": "3.6.0",
   "gates": { "handoff-set": "pass", "manifest-schema": "pass", "grounding": "pass",
-             "pinned-dep": "self", "changelog-format": "pass", "version-sync": "pass" },
+             "pinned-dep": "self", "changelog-format": "pass", "version-sync": "pass",
+             "verify-workflow": "pass" },
   "checkedAt": "2026-07-18T00:00:00Z" }
 ```
+
+#### The `verify-workflow` gate: can the workflow that runs the gate skip it?
+
+Every other gate asks whether the repository is in a good state. This one asks
+whether the required check that ENFORCES that state can be made to report success
+without running, which no amount of repository state can reveal.
+
+`aahp-verify.yml` is meant to be a required status check. Wrap the job in an `if:`,
+or wrap the gate step inside it, and the check keeps its name, keeps being required,
+and keeps reporting success while it evaluates nothing. Branch protection is then
+satisfied by a verdict nobody produced. This is not only the Layer 2 drift gate
+going missing: Layer 1 MANIFEST checksum integrity is skipped with it.
+
+The defect cannot be seen from inside AAHP. The workflow AAHP ships is
+unconditional and `propagate.sh` copies it verbatim, so the weakening only ever
+exists in the consumer's copy. `aahp doctor` therefore audits the consumer's own
+`.github/workflows/`, and because the canonical workflow's last step runs
+`aahp doctor`, a repository that has weakened its gate now says so on its own
+pull requests.
+
+What is asserted is the CONSEQUENCE, "there exists an event on which this workflow
+concludes success without having run the gate at `--level ci`", not the file's
+shape. The findings:
+
+| Finding | The state it can reach |
+|---------|------------------------|
+| `job-conditional` | the hosting job carries an `if:`; when it is false the job is skipped and the required check is satisfied having run nothing |
+| `job-soft-failing` | the job sets `continue-on-error`, so it reports success when the gate fails |
+| `ci-step-conditional` | no step runs the gate at `--level ci` unconditionally, so on some events the job succeeds having verified nothing |
+| `ci-step-soft-failing` | the gate runs unconditionally and its result is discarded |
+| `no-ci-level` | the gate never runs at `--level ci`, so `AAHP_SKIP_VERIFY=1` is honoured and a workflow-level `env:` can set it |
+
+A repository whose workflows never run the gate reports `skip`: there is no CI
+backstop to weaken. A workflow that clearly hosts the gate but whose shape cannot
+be decided (the gate reached through a composite action, or a file that will not
+parse) reports `fail`, because undecided is not clean. Two shapes are deliberately
+NOT findings, because they fail closed rather than green: an `if:` on the checkout
+step alone (the gate then runs against an empty workspace and exits non-zero), and
+`paths:` filters that stop the workflow triggering (a required check that never
+reports leaves the pull request pending).
+
+If a class of change genuinely does not need the handoff gate, put that exemption
+INSIDE the gate, keyed on the change, where it is visible and testable. Do not put
+it around the step, keyed on who pushed it.
+
+AAHP ships no runtime dependencies, so this gate carries a small block-YAML reader
+rather than importing a parser. A hand-written parser that quietly disagrees with
+real YAML would be the worst possible engine for a security gate, so
+`tests/assert-workflow-parser-parity.mjs` compares it against a real YAML parser on
+every workflow in this repository and every fixture, on exactly the fields the
+audit reads and on the resulting findings.
 
 **`aahp check`** is the pass/fail counterpart to that record. Where `doctor` emits a
 conformance snapshot, `check` runs the config-driven governance gates as one aggregate

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -27,6 +27,7 @@ import { dirname, join, resolve } from 'node:path'
 import { existsSync, mkdirSync, copyFileSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { spawn, spawnSync } from 'node:child_process'
 import { resolveBash, toBashPath } from '../scripts/aahp-config.mjs'
+import { audit as auditVerifyWorkflow } from '../scripts/check-verify-workflow.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -688,6 +689,46 @@ function gateVersionSync(targetPath, config) {
   return { status: 'fail', reason: firstLine(r.stderr || r.stdout) }
 }
 
+// ---------------------------------------------------------------------------
+// verify-workflow gate - "can the workflow that runs me skip me?"
+//
+// Every other gate here asks whether the repository is in a good state. This one
+// asks whether the CHECK THAT ENFORCES that state can be made to report success
+// without running, which no amount of repository state can reveal. A consumer
+// that wraps the AAHP verify job (or the gate step inside it) in an `if:` keeps
+// the required check's name and its green tick while it evaluates nothing: Layer
+// 1 MANIFEST checksum integrity is skipped along with the Layer 2 drift gate.
+//
+// It cannot be caught inside AAHP, because the workflow AAHP ships and
+// propagate.sh copies is unconditional. It only exists in the consumer's copy,
+// so only a check running inside the consumer can see it. That is why it lives
+// in `doctor`: the canonical workflow's last step runs `aahp doctor`, so a
+// consumer that has weakened the gate now says so on its own pull requests.
+//
+// A repository with no such workflow SKIPs (nothing to weaken). A workflow that
+// hosts the gate but cannot be classified FAILs, because undecided is not clean.
+function gateVerifyWorkflow(targetPath) {
+  let result
+  try {
+    result = auditVerifyWorkflow(targetPath)
+  } catch (err) {
+    return { status: 'fail', reason: `could not audit the verify workflow: ${err.message}` }
+  }
+  if (result.verdict === 'absent') {
+    return { status: 'skip', reason: 'no workflow here runs the AAHP verify gate' }
+  }
+  if (result.verdict === 'enforced') {
+    const where = result.hosts.map((h) => `${h.file}:${h.job}`).join(', ')
+    return { status: 'pass', reason: `the gate runs unconditionally at --level ci (${where})` }
+  }
+  if (result.verdict === 'unclassifiable') {
+    return { status: 'fail', reason: `undecidable verify workflow: ${result.unclassifiable[0]}` }
+  }
+  const first = result.findings[0]
+  const more = result.findings.length > 1 ? ` (+${result.findings.length - 1} more)` : ''
+  return { status: 'fail', reason: `the gate can be skipped [${first.id}] ${first.detail}${more}` }
+}
+
 function cmdDoctor(targetPath, flags) {
   const jsonOnly = flags.includes('--json')
   const quiet = flags.includes('--quiet')
@@ -706,6 +747,9 @@ function cmdDoctor(targetPath, flags) {
     'pinned-dep': gatePinnedDep(targetPath, pkg, config),
     'changelog-format': gateChangelogFormat(targetPath, config),
     'version-sync': gateVersionSync(targetPath, config),
+    // Evaluated in governance mode too: a repo can adopt the CI backstop
+    // without adopting the handoff files, and weakening it matters either way.
+    'verify-workflow': gateVerifyWorkflow(targetPath),
   }
 
   const gates = {}

--- a/scripts/check-verify-workflow.mjs
+++ b/scripts/check-verify-workflow.mjs
@@ -1,0 +1,587 @@
+#!/usr/bin/env node
+/**
+ * check-verify-workflow.mjs - can the workflow that runs the AAHP gate skip it?
+ *
+ * The required status check named after the AAHP verify job is the off-machine
+ * backstop for the whole protocol. A consumer that wraps that job (or the step
+ * inside it) in an `if:` keeps the check NAME, keeps it required, and keeps it
+ * green - while the job evaluates nothing at all. Branch protection is then
+ * satisfied by a check that never ran, and Layer 1 MANIFEST checksum integrity
+ * is skipped along with the Layer 2 drift gate.
+ *
+ * That defect is invisible from inside AAHP: the canonical workflow AAHP ships
+ * is unconditional, and propagate.sh copies it verbatim. It only exists in a
+ * consumer's copy, and only a check that runs INSIDE the consumer can see it.
+ * This gate is that check. `aahp doctor` runs it, so every consumer that runs
+ * doctor reports whether the workflow hosting the gate can skip the gate.
+ *
+ * WHAT IS ASSERTED IS THE CONSEQUENCE, not the file's shape: "there exists an
+ * event on which this workflow concludes SUCCESS without having executed the
+ * AAHP verify gate at --level ci". Each finding below names one way to reach
+ * that state.
+ *
+ * Deliberately NOT flagged, because they fail CLOSED (a blocked pull request,
+ * never a false green): an `if:` on the checkout step alone (the gate then runs
+ * against an empty workspace and exits non-zero), and `paths:` filters that stop
+ * the workflow from triggering (a required check that never reports leaves the
+ * pull request pending).
+ *
+ * Usage: node scripts/check-verify-workflow.mjs [path-to-project] [--json]
+ * Exit:  0 enforced or not adopted here
+ *        1 the gate can be skipped (findings printed)
+ *        2 a workflow hosts the gate but its shape cannot be classified, or IO
+ *          error. Never silently 0: unclassifiable is not clean.
+ *
+ * No runtime dependencies (AAHP ships none), so the YAML needed here is parsed
+ * by the small block-subset reader below. tests/verify-workflow.bats cross-checks
+ * that reader against the real `yaml` package on every workflow in this repo and
+ * on every fixture, so a divergence fails the suite rather than this gate.
+ */
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve, basename } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Minimal block-YAML reader
+//
+// Covers the subset GitHub workflow files actually use: block mappings, block
+// sequences, plain/quoted scalars, block scalars (| and >), flow collections,
+// and comments. Anything it cannot read raises, and the caller turns that into
+// exit 2 rather than a pass.
+// ---------------------------------------------------------------------------
+
+export class YamlSubsetError extends Error {}
+
+function toLines(text) {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((raw, n) => {
+      const m = /^([ \t]*)(.*)$/.exec(raw);
+      return { n: n + 1, indent: m[1].replace(/\t/g, "  ").length, body: m[2] };
+    });
+}
+
+/** Strip a trailing `# comment`, honouring quotes so a `#` inside a string survives. */
+export function stripComment(s) {
+  let out = "";
+  let quote = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      out += c;
+      if (c === quote) {
+        if (quote === "'" && s[i + 1] === "'") {
+          out += s[++i];
+          continue;
+        }
+        if (quote === '"' && s[i - 1] === "\\") continue;
+        quote = null;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      out += c;
+      continue;
+    }
+    if (c === "#" && (i === 0 || /\s/.test(s[i - 1]))) break;
+    out += c;
+  }
+  return out;
+}
+
+function readQuoted(s, start) {
+  const q = s[start];
+  let out = "";
+  for (let i = start + 1; i < s.length; i++) {
+    const c = s[i];
+    if (q === "'" ) {
+      if (c === "'") {
+        if (s[i + 1] === "'") { out += "'"; i++; continue; }
+        return [out, i + 1];
+      }
+      out += c;
+      continue;
+    }
+    if (c === "\\") {
+      const nxt = s[++i];
+      out += nxt === "n" ? "\n" : nxt === "t" ? "\t" : nxt;
+      continue;
+    }
+    if (c === '"') return [out, i + 1];
+    out += c;
+  }
+  throw new YamlSubsetError(`unterminated quoted scalar: ${s}`);
+}
+
+/** Split `key: rest` at the first structural colon. Returns null when there is none. */
+export function splitKey(body) {
+  if (body[0] === '"' || body[0] === "'") {
+    const [key, idx] = readQuoted(body, 0);
+    const tail = body.slice(idx);
+    if (!tail.startsWith(":")) return null;
+    return { key, rest: tail.slice(1).trim() };
+  }
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === ":" && (i + 1 === body.length || /\s/.test(body[i + 1]))) {
+      return { key: body.slice(0, i).trim(), rest: body.slice(i + 1).trim() };
+    }
+  }
+  return null;
+}
+
+function parseScalar(raw) {
+  const s = raw.trim();
+  if (s === "") return null;
+  if (s[0] === '"' || s[0] === "'") return readQuoted(s, 0)[0];
+  if (s === "null" || s === "~") return null;
+  if (s === "true") return true;
+  if (s === "false") return false;
+  if (/^-?\d+$/.test(s)) return Number(s);
+  return s;
+}
+
+function splitFlow(inner) {
+  const parts = [];
+  let depth = 0;
+  let quote = null;
+  let cur = "";
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (quote) {
+      cur += c;
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; cur += c; continue; }
+    if (c === "[" || c === "{") depth++;
+    if (c === "]" || c === "}") depth--;
+    if (c === "," && depth === 0) { parts.push(cur); cur = ""; continue; }
+    cur += c;
+  }
+  if (cur.trim() !== "") parts.push(cur);
+  return parts;
+}
+
+function parseFlow(s) {
+  const t = s.trim();
+  if (t.startsWith("[")) {
+    if (!t.endsWith("]")) throw new YamlSubsetError(`unterminated flow sequence: ${s}`);
+    return splitFlow(t.slice(1, -1)).map((p) => parseFlowItem(p));
+  }
+  if (!t.endsWith("}")) throw new YamlSubsetError(`unterminated flow mapping: ${s}`);
+  const out = {};
+  for (const p of splitFlow(t.slice(1, -1))) {
+    const kv = splitKey(p.trim());
+    if (!kv) throw new YamlSubsetError(`flow mapping entry without a key: ${p}`);
+    out[kv.key] = parseFlowItem(kv.rest);
+  }
+  return out;
+}
+
+function parseFlowItem(p) {
+  const t = p.trim();
+  if (t.startsWith("[") || t.startsWith("{")) return parseFlow(t);
+  return parseScalar(t);
+}
+
+function skipIgnorable(lines, cur) {
+  while (cur.i < lines.length) {
+    const t = lines[cur.i].body.trim();
+    if (t === "" || t.startsWith("#") || t === "---" || t === "...") { cur.i++; continue; }
+    break;
+  }
+}
+
+function parseBlockScalar(lines, cur, parentIndent, header) {
+  const style = header[0];
+  const chomp = /-/.test(header) ? "strip" : /\+/.test(header) ? "keep" : "clip";
+  const collected = [];
+  let contentIndent = null;
+  while (cur.i < lines.length) {
+    const ln = lines[cur.i];
+    if (ln.body.trim() === "") { collected.push(""); cur.i++; continue; }
+    if (ln.indent <= parentIndent) break;
+    if (contentIndent === null) contentIndent = ln.indent;
+    // Keep indentation RELATIVE to the block's own first line, so nesting inside
+    // the scalar survives while the block's base indent is removed.
+    collected.push(" ".repeat(Math.max(0, ln.indent - contentIndent)) + ln.body);
+    cur.i++;
+  }
+  while (collected.length && collected[collected.length - 1] === "") collected.pop();
+  let text;
+  if (style === "|") {
+    text = collected.join("\n");
+  } else {
+    // Folded (`>`) is NOT "join every line with a space". A line indented deeper
+    // than the block's first content line is "more indented": YAML keeps its
+    // line break and its extra indentation instead of folding it. A wrapped
+    // `if:` written as a folded scalar is exactly that shape, and folding it
+    // anyway produced text no reference parser agrees with.
+    let out = "";
+    let started = false;
+    let prevMore = false;
+    let blanks = 0;
+    for (const line of collected) {
+      if (line === "") { blanks++; continue; }
+      const more = /^\s/.test(line);
+      if (!started) {
+        out = line;
+        started = true;
+      } else if (blanks > 0) {
+        out += "\n".repeat(blanks) + line;
+      } else {
+        out += (more || prevMore ? "\n" : " ") + line;
+      }
+      prevMore = more;
+      blanks = 0;
+    }
+    text = out;
+  }
+  if (chomp === "clip" && text !== "") text += "\n";
+  if (chomp === "keep") text += "\n";
+  return text;
+}
+
+// A plain scalar may continue on the following, MORE indented lines; YAML folds
+// them with a single space. A long `if:` is written this way in real workflows,
+// so reading only the first line would compare the wrong text (or, worse, treat
+// the continuation as an unexpected indent and give up on the whole file).
+// Once a value starts on the key's own line, every more-indented line belongs
+// to it: a nested block cannot follow a key that already has a value.
+function foldPlainContinuation(lines, cur, indent, first) {
+  let text = first;
+  while (cur.i < lines.length) {
+    const ln = lines[cur.i];
+    if (ln.body.trim() === "") {
+      // Peek: a blank line only continues the scalar if more indented text follows.
+      let j = cur.i;
+      while (j < lines.length && lines[j].body.trim() === "") j++;
+      if (j >= lines.length || lines[j].indent <= indent) break;
+      text += "\n";
+      cur.i = j;
+      continue;
+    }
+    if (ln.indent <= indent) break;
+    text += (text.endsWith("\n") ? "" : " ") + stripComment(ln.body).trim();
+    cur.i++;
+  }
+  return text;
+}
+
+function parseValueAfterKey(lines, cur, indent, rest) {
+  const trimmed = stripComment(rest).trim();
+  if (trimmed !== "") {
+    if (/^[|>][-+]?$/.test(trimmed) || /^[|>][-+]?\d+$/.test(trimmed)) {
+      return parseBlockScalar(lines, cur, indent, trimmed);
+    }
+    if (trimmed.startsWith("[") || trimmed.startsWith("{")) return parseFlow(trimmed);
+    if (trimmed[0] === '"' || trimmed[0] === "'") return parseScalar(trimmed);
+    return parseScalar(foldPlainContinuation(lines, cur, indent, trimmed));
+  }
+  skipIgnorable(lines, cur);
+  if (cur.i >= lines.length) return null;
+  const nxt = lines[cur.i];
+  if (nxt.indent > indent) return parseBlock(lines, cur, nxt.indent);
+  if (nxt.indent === indent && /^-(\s|$)/.test(nxt.body)) return parseSeq(lines, cur, indent);
+  return null;
+}
+
+function parseMap(lines, cur, indent) {
+  const out = {};
+  for (;;) {
+    skipIgnorable(lines, cur);
+    if (cur.i >= lines.length) break;
+    const ln = lines[cur.i];
+    if (ln.indent < indent) break;
+    if (/^-(\s|$)/.test(ln.body)) break;
+    if (ln.indent > indent) {
+      throw new YamlSubsetError(`unexpected indentation on line ${ln.n}: ${ln.body}`);
+    }
+    const kv = splitKey(ln.body);
+    if (!kv) throw new YamlSubsetError(`line ${ln.n} is not a mapping entry: ${ln.body}`);
+    cur.i++;
+    out[kv.key] = parseValueAfterKey(lines, cur, indent, kv.rest);
+  }
+  return out;
+}
+
+function parseSeq(lines, cur, indent) {
+  const out = [];
+  for (;;) {
+    skipIgnorable(lines, cur);
+    if (cur.i >= lines.length) break;
+    const ln = lines[cur.i];
+    if (ln.indent !== indent || !/^-(\s|$)/.test(ln.body)) break;
+    const after = ln.body.slice(1);
+    const lead = after.length - after.replace(/^\s+/, "").length;
+    const content = after.trim();
+    if (content === "" || content.startsWith("#")) {
+      cur.i++;
+      out.push(parseBlock(lines, cur, indent + 1));
+      continue;
+    }
+    const contentIndent = indent + 1 + lead;
+    lines[cur.i] = { n: ln.n, indent: contentIndent, body: content };
+    if (/^-(\s|$)/.test(content)) {
+      out.push(parseSeq(lines, cur, contentIndent));
+    } else if (splitKey(content)) {
+      out.push(parseMap(lines, cur, contentIndent));
+    } else {
+      out.push(parseScalar(stripComment(content)));
+      cur.i++;
+    }
+  }
+  return out;
+}
+
+function parseBlock(lines, cur, indent) {
+  skipIgnorable(lines, cur);
+  if (cur.i >= lines.length) return null;
+  const ln = lines[cur.i];
+  if (ln.indent < indent) return null;
+  if (/^-(\s|$)/.test(ln.body)) return parseSeq(lines, cur, ln.indent);
+  return parseMap(lines, cur, ln.indent);
+}
+
+/** Parse the block-YAML subset GitHub workflow files use. Throws YamlSubsetError. */
+export function parseYamlSubset(text) {
+  const lines = toLines(text);
+  const cur = { i: 0 };
+  const value = parseBlock(lines, cur, 0);
+  skipIgnorable(lines, cur);
+  if (cur.i < lines.length) {
+    throw new YamlSubsetError(`trailing content at line ${lines[cur.i].n}: ${lines[cur.i].body}`);
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// The audit
+// ---------------------------------------------------------------------------
+
+// A step runs the AAHP gate when its `run:` invokes the vendored script or the
+// CLI. Anchored on the INVOCATION, not on a file name or a job id, so renaming
+// the workflow cannot hide the job from this gate.
+//
+// The CLI form must tolerate a package SPEC, not just the bare binary name: a
+// consumer that runs `npx -y @scope/aahp@3.10.0 verify . --level ci` is running
+// the gate, and an earlier draft of this pattern missed exactly that shape in
+// two live consumers. `aahp-verify` (the job id) cannot match, because what
+// follows `aahp` must be whitespace or an `@version`.
+const RUNS_VERIFY = [
+  /verify-handoff\.sh/,
+  /(^|[\s"'/@])aahp(@[^\s"']*)?\s+verify(\s|$)/,
+  /aahp\.js\s+verify(\s|$)/,
+];
+const CI_LEVEL = /--level[\s=]+ci\b/;
+
+export function runsVerify(run) {
+  return typeof run === "string" && RUNS_VERIFY.some((re) => re.test(run));
+}
+
+export function isCiLevel(run) {
+  return typeof run === "string" && CI_LEVEL.test(run);
+}
+
+// `continue-on-error` is a bypass unless it is literally false. An expression
+// (`${{ ... }}`) can evaluate true, and this gate cannot evaluate it, so it
+// counts as reachable.
+function softFailing(value) {
+  if (value === undefined || value === null || value === false) return false;
+  if (typeof value === "string" && value.trim().toLowerCase() === "false") return false;
+  return true;
+}
+
+function describeStep(step, index) {
+  const name = typeof step.name === "string" && step.name ? step.name : `step ${index + 1}`;
+  return name;
+}
+
+/**
+ * Audit one parsed workflow document.
+ * Returns { hosts, findings } where hosts is the list of jobs that run the gate.
+ */
+export function auditDoc(doc, file) {
+  const findings = [];
+  const hosts = [];
+  const jobs = doc && typeof doc === "object" && doc.jobs && typeof doc.jobs === "object" ? doc.jobs : null;
+  if (!jobs) return { hosts, findings };
+
+  for (const [jobId, job] of Object.entries(jobs)) {
+    if (!job || typeof job !== "object") continue;
+    const steps = Array.isArray(job.steps) ? job.steps.filter((s) => s && typeof s === "object") : [];
+    const verifySteps = steps
+      .map((s, i) => ({ step: s, i }))
+      .filter(({ step }) => runsVerify(step.run));
+    if (verifySteps.length === 0) continue;
+    hosts.push({ file, job: jobId });
+    const at = `${file}: job "${jobId}"`;
+
+    if (job.if !== undefined && job.if !== null) {
+      findings.push({
+        id: "job-conditional",
+        detail:
+          `${at} carries a job-level \`if:\` (${String(job.if).trim()}). ` +
+          "When it evaluates false the job is skipped, the required check reports " +
+          "success or is treated as satisfied, and no layer of the gate ran.",
+      });
+    }
+    if (softFailing(job["continue-on-error"])) {
+      findings.push({
+        id: "job-soft-failing",
+        detail: `${at} sets continue-on-error, so the job reports success even when the gate fails.`,
+      });
+    }
+
+    const ciSteps = verifySteps.filter(({ step }) => isCiLevel(step.run));
+    if (ciSteps.length === 0) {
+      findings.push({
+        id: "no-ci-level",
+        detail:
+          `${at} runs the gate but never at \`--level ci\`. Every other level honours ` +
+          "AAHP_SKIP_VERIFY=1, so the off-machine backstop has an environment-variable bypass.",
+      });
+      continue;
+    }
+
+    const unconditional = ciSteps.filter(({ step }) => step.if === undefined || step.if === null);
+    if (unconditional.length === 0) {
+      const conds = ciSteps
+        .map(({ step, i }) => `"${describeStep(step, i)}" if: ${String(step.if).trim()}`)
+        .join("; ");
+      findings.push({
+        id: "ci-step-conditional",
+        detail:
+          `${at} runs the gate at --level ci only under a condition (${conds}). ` +
+          "On the events where that condition is false the job still reports success, " +
+          "having verified nothing: Layer 1 MANIFEST checksum integrity is skipped too, " +
+          "not only the Layer 2 drift gate. Put the exemption INSIDE the gate, keyed on " +
+          "the change, not around the step, keyed on who pushed it.",
+      });
+      continue;
+    }
+
+    const hard = unconditional.filter(({ step }) => !softFailing(step["continue-on-error"]));
+    if (hard.length === 0) {
+      findings.push({
+        id: "ci-step-soft-failing",
+        detail:
+          `${at} runs the gate at --level ci unconditionally, but every such step sets ` +
+          "continue-on-error, so a failing gate still leaves the check green.",
+      });
+    }
+  }
+
+  return { hosts, findings };
+}
+
+// A workflow file that is clearly the AAHP verify workflow but exposes no `run:`
+// invoking the gate is UNCLASSIFIABLE, not clean: the gate may be reached through
+// a composite action or a reusable workflow this reader cannot follow.
+function looksLikeVerifyWorkflow(file, doc) {
+  if (basename(file) === "aahp-verify.yml" || basename(file) === "aahp-verify.yaml") return true;
+  const name = doc && typeof doc === "object" ? doc.name : null;
+  return typeof name === "string" && /^aahp\s+verify$/i.test(name.trim());
+}
+
+export function audit(root) {
+  const dir = join(root, ".github", "workflows");
+  const result = { verdict: "absent", hosts: [], findings: [], unclassifiable: [] };
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return result; // no workflows directory: the CI backstop is not adopted here
+  }
+
+  for (const entry of entries.sort()) {
+    if (!/\.ya?ml$/i.test(entry)) continue;
+    const file = `.github/workflows/${entry}`;
+    const path = join(dir, entry);
+    let text;
+    try {
+      text = readFileSync(path, "utf8");
+    } catch (err) {
+      result.unclassifiable.push(`${file}: cannot read (${err.message})`);
+      continue;
+    }
+    let doc;
+    try {
+      doc = parseYamlSubset(text);
+    } catch (err) {
+      // Only a workflow that plausibly hosts the gate matters here. An unrelated
+      // workflow this reader cannot parse is not this gate's business.
+      if (looksLikeVerifyWorkflow(file, null) || /verify-handoff\.sh|aahp\s+verify/.test(text)) {
+        result.unclassifiable.push(`${file}: cannot be parsed (${err.message})`);
+      }
+      continue;
+    }
+    const { hosts, findings } = auditDoc(doc, file);
+    result.hosts.push(...hosts);
+    result.findings.push(...findings);
+    if (hosts.length === 0 && looksLikeVerifyWorkflow(file, doc)) {
+      result.unclassifiable.push(
+        `${file}: no step runs the AAHP verify gate directly, so whether the gate can be ` +
+          "skipped cannot be decided from this file (a composite action or reusable workflow?).",
+      );
+    }
+  }
+
+  if (result.unclassifiable.length > 0) result.verdict = "unclassifiable";
+  else if (result.findings.length > 0) result.verdict = "bypassable";
+  else if (result.hosts.length > 0) result.verdict = "enforced";
+  else result.verdict = "absent";
+  return result;
+}
+
+const EXIT = { enforced: 0, absent: 0, bypassable: 1, unclassifiable: 2 };
+
+export function main(argv = process.argv.slice(2)) {
+  const flags = argv.filter((a) => a.startsWith("--"));
+  const root = resolve(argv.find((a) => !a.startsWith("--")) || ".");
+  if (!existsSync(root)) {
+    console.error(`check-verify-workflow: no such path: ${root}`);
+    return 2;
+  }
+  const result = audit(root);
+
+  if (flags.includes("--json")) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return EXIT[result.verdict];
+  }
+
+  if (result.verdict === "absent") {
+    console.log(
+      "check-verify-workflow: SKIP - no workflow here runs the AAHP verify gate, so there is no CI backstop to weaken.",
+    );
+    return 0;
+  }
+  if (result.verdict === "enforced") {
+    const where = result.hosts.map((h) => `${h.file}:${h.job}`).join(", ");
+    console.log(`check-verify-workflow: OK - the gate runs unconditionally at --level ci (${where}).`);
+    return 0;
+  }
+  if (result.verdict === "unclassifiable") {
+    console.error("check-verify-workflow: UNDECIDED - the gate's workflow could not be classified:");
+    for (const u of result.unclassifiable) console.error(`  ${u}`);
+    console.error("Undecided is not clean. Resolve the shape, or run the gate from a plain `run:` step.");
+    return 2;
+  }
+
+  console.error("check-verify-workflow: FAIL - the workflow that runs the AAHP gate can skip it:");
+  for (const f of result.findings) console.error(`  [${f.id}] ${f.detail}`);
+  console.error(
+    "A required check that reports success without running is worse than no check: it is " +
+      "branch protection reporting a verdict nobody produced.",
+  );
+  return 1;
+}
+
+const isMain =
+  process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+
+if (isMain) {
+  process.exit(main());
+}

--- a/tests/assert-workflow-parser-parity.mjs
+++ b/tests/assert-workflow-parser-parity.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// assert-workflow-parser-parity.mjs - the zero-dependency reader must agree
+// with a real YAML parser.
+//
+// check-verify-workflow.mjs cannot depend on a YAML package: AAHP ships no
+// runtime dependencies, and the gate has to run inside a consumer that only
+// installed the CLI. So it carries a small block-YAML reader. A hand-written
+// parser that quietly disagrees with real YAML is the worst possible engine for
+// a security gate - it would report "enforced" on a workflow it misread.
+//
+// This asserts the disagreement cannot happen unnoticed, over every workflow in
+// this repository plus every fixture under tests/fixtures/workflows/, on exactly
+// the fields the audit consumes (job `if`, job `continue-on-error`, and each
+// step's name/run/uses/if/continue-on-error) AND on the resulting finding ids.
+// `yaml` is a devDependency, so this runs in CI and never in a consumer.
+//
+// Both DIRECTIONS matter and both are covered by the fixture set: workflows that
+// must come out enforced, and workflows that must come out bypassable.
+//
+// Kept as a file rather than an inline `node -e` for the reason recorded in
+// tests/assert-repo-ci-shape.mjs: under Git Bash a POSIX path inside a quoted
+// -e string is not converted for the native node binary.
+//
+// Usage: node tests/assert-workflow-parser-parity.mjs [repo-root]
+// Exit:  0 parity holds, 1 a divergence was found, 2 nothing was compared.
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { parse } from "yaml";
+import { parseYamlSubset, auditDoc } from "../scripts/check-verify-workflow.mjs";
+
+const root = resolve(process.argv[2] || ".");
+
+// Project a parsed document down to the fields the audit reads. Everything else
+// is free to differ: this gate never looks at it.
+function projection(doc) {
+  const jobs = doc && typeof doc === "object" && doc.jobs && typeof doc.jobs === "object" ? doc.jobs : {};
+  const str = (v) => (v === undefined ? null : String(v));
+  const out = {};
+  for (const [id, job] of Object.entries(jobs)) {
+    if (!job || typeof job !== "object") continue;
+    const steps = Array.isArray(job.steps) ? job.steps : [];
+    out[id] = {
+      if: str(job.if),
+      coe: str(job["continue-on-error"]),
+      steps: steps.map((s) =>
+        s && typeof s === "object"
+          ? { name: str(s.name), run: str(s.run), uses: str(s.uses), if: str(s.if), coe: str(s["continue-on-error"]) }
+          : null,
+      ),
+    };
+  }
+  return out;
+}
+
+const dirs = [join(root, ".github", "workflows"), join(root, "tests", "fixtures", "workflows")];
+const problems = [];
+let compared = 0;
+
+for (const dir of dirs) {
+  if (!existsSync(dir)) continue;
+  for (const entry of readdirSync(dir).sort()) {
+    if (!/\.ya?ml$/i.test(entry)) continue;
+    const path = join(dir, entry);
+    const label = relative(root, path).replace(/\\/g, "/");
+    const text = readFileSync(path, "utf8");
+
+    let reference;
+    try {
+      reference = parse(text);
+    } catch (err) {
+      problems.push(`${label}: the reference parser rejects this fixture (${err.message}); fix the fixture`);
+      continue;
+    }
+
+    let mine;
+    try {
+      mine = parseYamlSubset(text);
+    } catch (err) {
+      problems.push(`${label}: the AAHP reader cannot parse a file real YAML accepts (${err.message})`);
+      continue;
+    }
+
+    compared++;
+    const a = JSON.stringify(projection(reference));
+    const b = JSON.stringify(projection(mine));
+    if (a !== b) {
+      problems.push(`${label}: the AAHP reader disagrees with real YAML on the audited fields\n      yaml: ${a.slice(0, 400)}\n      aahp: ${b.slice(0, 400)}`);
+      continue;
+    }
+
+    const fa = auditDoc(reference, label).findings.map((f) => f.id).sort().join(",");
+    const fb = auditDoc(mine, label).findings.map((f) => f.id).sort().join(",");
+    if (fa !== fb) {
+      problems.push(`${label}: same file, different verdict: yaml=[${fa}] aahp=[${fb}]`);
+    }
+  }
+}
+
+if (compared === 0) {
+  console.error("workflow parser parity: nothing was compared. A green run here would mean nothing.");
+  process.exit(2);
+}
+if (problems.length > 0) {
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log(`workflow parser parity OK (${compared} workflow file(s))`);

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -59,7 +59,7 @@ EOF
       process.stdin.on("data", (d) => (s += d)).on("end", () => {
         const r = JSON.parse(s);
         if (r.schemaVersion !== 1) process.exit(2);
-        const keys = ["handoff-set","manifest-schema","grounding","pinned-dep","changelog-format","version-sync"];
+        const keys = ["handoff-set","manifest-schema","grounding","pinned-dep","changelog-format","version-sync","verify-workflow"];
         for (const k of keys) if (!(k in r.gates)) process.exit(3);
         if (typeof r.checkedAt !== "string") process.exit(4);
         if (typeof r.aahpVersion !== "string") process.exit(5);
@@ -224,7 +224,7 @@ EOF
     ' "$gov" "$nh"
 }
 
-@test "doctor --governance --json emits mode:governance with all six gate keys and the 3 handoff gates skip" {
+@test "doctor --governance --json emits mode:governance with all seven gate keys and the 3 handoff gates skip" {
     scaffold_conformant
     rm -rf "$TEST_TMPDIR/.ai"
     run node "$AAHP" doctor "$TEST_TMPDIR" --governance --json
@@ -234,7 +234,7 @@ EOF
       process.stdin.on("data", (d) => (s += d)).on("end", () => {
         const r = JSON.parse(s);
         if (r.mode !== "governance") process.exit(2);
-        const keys = ["handoff-set","manifest-schema","grounding","pinned-dep","changelog-format","version-sync"];
+        const keys = ["handoff-set","manifest-schema","grounding","pinned-dep","changelog-format","version-sync","verify-workflow"];
         for (const k of keys) if (!(k in r.gates)) process.exit(3);
         for (const k of ["handoff-set", "manifest-schema", "grounding"]) {
           if (r.gates[k] !== "skip") process.exit(4);

--- a/tests/fixtures/workflows/bypass-job-conditional.yml
+++ b/tests/fixtures/workflows/bypass-job-conditional.yml
@@ -1,0 +1,20 @@
+# Fixture: the whole job is conditional. The check is still required and still
+# named, and a skipped job satisfies branch protection.
+# Expected verdict: bypassable (job-conditional).
+name: AAHP Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.user.login != 'dependabot[bot]'
+        && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Run aahp verify (CI level, no escape hatch)
+        run: bash scripts/verify-handoff.sh . --level ci

--- a/tests/fixtures/workflows/bypass-no-ci-level.yml
+++ b/tests/fixtures/workflows/bypass-no-ci-level.yml
@@ -1,0 +1,18 @@
+# Fixture: the gate runs, but not at --level ci. Every other level honours
+# AAHP_SKIP_VERIFY=1, so the off-machine backstop has an environment-variable
+# bypass that a workflow-level `env:` can set.
+# Expected verdict: bypassable (no-ci-level).
+name: AAHP Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Run aahp verify
+        run: bash scripts/verify-handoff.sh . --level full

--- a/tests/fixtures/workflows/bypass-partial-layer1.yml
+++ b/tests/fixtures/workflows/bypass-partial-layer1.yml
@@ -1,0 +1,28 @@
+# Fixture: the "partial exemption" shape. A bot change still gets a verify run,
+# but not at --level ci, so the escape hatch is honoured and the drift gate is
+# gone. Every step that reaches --level ci is conditional, which is the defect:
+# a green tick that means "Layer 1 only" is indistinguishable from one that
+# means "all four layers".
+# Expected verdict: bypassable (ci-step-conditional).
+name: AAHP Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    env:
+      IS_BOT: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: 'Run aahp verify (bot: integrity only)'
+        if: ${{ env.IS_BOT == 'true' }}
+        run: bash scripts/verify-handoff.sh . --level prepush
+
+      - name: Run aahp verify (CI level, no escape hatch)
+        if: ${{ env.IS_BOT != 'true' }}
+        run: bash scripts/verify-handoff.sh . --level ci

--- a/tests/fixtures/workflows/bypass-soft-failing.yml
+++ b/tests/fixtures/workflows/bypass-soft-failing.yml
@@ -1,0 +1,17 @@
+# Fixture: the gate runs unconditionally and its result is thrown away.
+# Expected verdict: bypassable (ci-step-soft-failing).
+name: AAHP Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Run aahp verify (CI level, no escape hatch)
+        continue-on-error: true
+        run: bash scripts/verify-handoff.sh . --level ci

--- a/tests/fixtures/workflows/bypass-step-conditional.yml
+++ b/tests/fixtures/workflows/bypass-step-conditional.yml
@@ -1,0 +1,29 @@
+# Fixture: the shape measured in live consumers. The required check keeps its
+# name and its green tick, and on a bot-authored change every gate step is
+# skipped, so the job succeeds having evaluated nothing.
+# Expected verdict: bypassable (ci-step-conditional).
+name: AAHP Verify
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    env:
+      IS_BOT: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Announce the exemption
+        if: ${{ env.IS_BOT == 'true' }}
+        run: echo 'bot change, so the handoff gate does not apply.'
+
+      - name: Checkout code
+        if: ${{ env.IS_BOT != 'true' }}
+        uses: actions/checkout@v5
+
+      - name: Run aahp verify (CI level, no escape hatch)
+        if: ${{ env.IS_BOT != 'true' }}
+        run: bash scripts/verify-handoff.sh . --level ci

--- a/tests/fixtures/workflows/enforced-canonical.yml
+++ b/tests/fixtures/workflows/enforced-canonical.yml
@@ -1,0 +1,25 @@
+# Fixture: the canonical shape propagate.sh installs. Nothing can skip the gate.
+# Expected verdict: enforced.
+name: AAHP Verify
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run aahp verify (CI level, no escape hatch)
+        run: bash scripts/verify-handoff.sh . --level ci
+
+      - name: Run aahp doctor (conformance record)
+        run: node bin/aahp.js doctor . --json

--- a/tests/fixtures/workflows/enforced-fails-closed-shapes.yml
+++ b/tests/fixtures/workflows/enforced-fails-closed-shapes.yml
@@ -1,0 +1,38 @@
+# Fixture: the two shapes that are deliberately NOT findings, because both fail
+# CLOSED rather than green.
+#
+#   `paths:` filters - the workflow does not trigger at all on a change that
+#   matches nothing, so a required check never reports and the pull request sits
+#   pending. That blocks a merge; it does not wave one through.
+#
+#   an `if:` on the CHECKOUT step alone - the gate step still runs, against an
+#   empty workspace, and exits non-zero because `.ai/handoff` is not there.
+#
+# Documented behaviour with no test is how the defect this gate exists for got
+# in, so the exemption is pinned here rather than only described in the README.
+# Expected verdict: enforced.
+name: AAHP Verify
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - '.ai/handoff/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run aahp verify (CI level, no escape hatch)
+        run: bash scripts/verify-handoff.sh . --level ci

--- a/tests/fixtures/workflows/enforced-npx-package-spec.yml
+++ b/tests/fixtures/workflows/enforced-npx-package-spec.yml
@@ -1,0 +1,45 @@
+# Fixture: a consumer with no vendored script runs the published CLI by exact
+# version. Regression guard: an earlier draft of the invocation pattern matched
+# `aahp verify` but NOT `aahp@3.10.0 verify`, and so reported two live consumers
+# as undecidable instead of naming their bypass. The tricky YAML below (folded
+# scalar with a more-indented line, a literal block containing a `#`, a quoted
+# key holding a colon, flow sequences, an explicit `continue-on-error: false`)
+# is here on purpose: it is the reader's hard case, and the parity test compares
+# it against a real YAML parser.
+# Expected verdict: enforced.
+name: AAHP Verify
+
+on:
+  push:
+    branches: [main, release]
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: 'Report the level: ci, and nothing weaker'
+        run: |
+          # A comment containing a colon: and a # hash, inside a literal block.
+          echo "level: ci"
+
+      - name: Run aahp verify (CI level, no escape hatch)
+        continue-on-error: false
+        run: npx -y @scope_example/aahp@3.10.0 verify . --level ci
+        env:
+          AAHP_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+  advisory:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request'
+        && github.event.pull_request.draft == false
+    steps:
+      - name: Something unrelated that may be skipped
+        run: echo 'this job does not host the gate, so its condition is nobody business'

--- a/tests/fixtures/workflows/undecidable-indirect.yml
+++ b/tests/fixtures/workflows/undecidable-indirect.yml
@@ -1,0 +1,18 @@
+# Fixture: the workflow is clearly the AAHP verify workflow, but it reaches the
+# gate through an action this reader cannot follow. Whether the gate can be
+# skipped is then undecided, and undecided must not be reported as clean.
+# Expected verdict: unclassifiable.
+name: AAHP Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  aahp-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Run the handoff gate
+        uses: ./.github/actions/run-aahp-gate

--- a/tests/verify-workflow.bats
+++ b/tests/verify-workflow.bats
@@ -56,6 +56,19 @@ install_workflow() {
     [ "$status" -eq 0 ]
 }
 
+@test "enforced: paths filters and a checkout-only if: are NOT findings" {
+    # Both fail CLOSED, so neither can produce a green tick over an unrun gate:
+    # a `paths:` filter leaves a required check pending (the pull request is
+    # blocked), and skipping only the checkout leaves the gate running against an
+    # empty workspace, where it exits non-zero. Pinned as a test because a
+    # documented-but-untested exemption is how the original defect got in.
+    install_workflow enforced-fails-closed-shapes.yml
+    run node "$GATE" "$TEST_TMPDIR" --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"verdict": "enforced"'* ]]
+    [[ "$output" != *"job-conditional"* ]]
+}
+
 # ─── bypassable: each way the check can go green having run nothing ──────────
 
 @test "bypassable: a step-level if: on the gate step is reported, exit 1" {

--- a/tests/verify-workflow.bats
+++ b/tests/verify-workflow.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+# verify-workflow.bats - "can the workflow that runs the AAHP gate skip it?"
+#
+# The gate under test answers one question about a CONSUMER: does there exist an
+# event on which the required AAHP check concludes SUCCESS without having run the
+# gate at --level ci? Both directions are asserted here. A gate that only ever
+# says "bypassable" would be as useless as one that only ever says "enforced",
+# and the enforced fixtures are what keep the failing ones meaningful.
+
+load test_helper
+
+GATE="$AAHP_ROOT/scripts/check-verify-workflow.mjs"
+AAHP="$AAHP_ROOT/bin/aahp.js"
+FIXTURES="$AAHP_ROOT/tests/fixtures/workflows"
+
+# Install one fixture as the repo's only workflow.
+install_workflow() {
+    mkdir -p "$TEST_TMPDIR/.github/workflows"
+    cp "$FIXTURES/$1" "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
+}
+
+# ─── enforced: the gate cannot be skipped ────────────────────────────────────
+
+@test "enforced: the canonical workflow propagate.sh installs exits 0" {
+    install_workflow enforced-canonical.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+    [[ "$output" == *"unconditionally at --level ci"* ]]
+}
+
+@test "enforced: the published CLI invoked by exact version is recognised" {
+    # Regression: `npx -y @scope/aahp@3.10.0 verify . --level ci` is a gate run.
+    # A pattern that missed the @version suffix called two live consumers
+    # undecidable and never named their bypass.
+    install_workflow enforced-npx-package-spec.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unconditionally at --level ci"* ]]
+}
+
+@test "enforced: an if: on a job that does NOT host the gate is not a finding" {
+    # enforced-npx-package-spec.yml carries a second, conditional job. Only the
+    # job that runs the gate is this gate's business; flagging the rest would be
+    # the false positive that gets a tool switched off.
+    install_workflow enforced-npx-package-spec.yml
+    run node "$GATE" "$TEST_TMPDIR" --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"verdict": "enforced"'* ]]
+    [[ "$output" != *"advisory"* ]]
+}
+
+@test "enforced: an explicit continue-on-error: false is not a bypass" {
+    install_workflow enforced-npx-package-spec.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+# ─── bypassable: each way the check can go green having run nothing ──────────
+
+@test "bypassable: a step-level if: on the gate step is reported, exit 1" {
+    install_workflow bypass-step-conditional.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ci-step-conditional"* ]]
+    [[ "$output" == *"Layer 1 MANIFEST checksum integrity is skipped too"* ]]
+}
+
+@test "bypassable: a job-level if: on the hosting job is reported, exit 1" {
+    install_workflow bypass-job-conditional.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"job-conditional"* ]]
+}
+
+@test "bypassable: a partial exemption that keeps a weaker level still fails" {
+    # A run that only reaches --level prepush honours AAHP_SKIP_VERIFY and skips
+    # the drift gate, yet reports under the same required check name.
+    install_workflow bypass-partial-layer1.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ci-step-conditional"* ]]
+}
+
+@test "bypassable: continue-on-error on the gate step is reported, exit 1" {
+    install_workflow bypass-soft-failing.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ci-step-soft-failing"* ]]
+}
+
+@test "bypassable: running the gate below --level ci is reported, exit 1" {
+    install_workflow bypass-no-ci-level.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no-ci-level"* ]]
+    [[ "$output" == *"AAHP_SKIP_VERIFY"* ]]
+}
+
+# ─── neither: absent, and undecidable ────────────────────────────────────────
+
+@test "absent: a repo with no workflows exits 0 and says there is no backstop" {
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP"* ]]
+    [[ "$output" == *"no CI backstop"* ]]
+}
+
+@test "absent: workflows that never run the gate are not this gate's business" {
+    mkdir -p "$TEST_TMPDIR/.github/workflows"
+    printf 'name: Build\non:\n  push:\njobs:\n  build:\n    if: github.ref == \x27refs/heads/main\x27\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm test\n' \
+        > "$TEST_TMPDIR/.github/workflows/ci.yml"
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIP"* ]]
+}
+
+@test "undecidable: the gate reached through an action exits 2, never 0" {
+    install_workflow undecidable-indirect.yml
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"UNDECIDED"* ]]
+    [[ "$output" == *"Undecided is not clean"* ]]
+}
+
+@test "undecidable: an unparseable verify workflow exits 2, never 0" {
+    mkdir -p "$TEST_TMPDIR/.github/workflows"
+    printf 'name: AAHP Verify\njobs:\n  aahp-verify:\n   steps:\n  - run: bash scripts/verify-handoff.sh . --level ci\n     bad: [unclosed\n' \
+        > "$TEST_TMPDIR/.github/workflows/aahp-verify.yml"
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"UNDECIDED"* ]]
+}
+
+@test "a broken workflow that has nothing to do with AAHP does not fail the gate" {
+    install_workflow enforced-canonical.yml
+    printf 'jobs:\n  build:\n   steps:\n  - bad: [unclosed\n' > "$TEST_TMPDIR/.github/workflows/other.yml"
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+# ─── the reader must agree with real YAML ────────────────────────────────────
+
+@test "the zero-dependency YAML reader agrees with a real parser on every workflow" {
+    # See tests/assert-workflow-parser-parity.mjs: the gate ships without a YAML
+    # dependency, so this is what stops its reader from drifting into misreading
+    # a workflow and calling it enforced.
+    run node "$AAHP_ROOT/tests/assert-workflow-parser-parity.mjs" "$AAHP_ROOT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"workflow parser parity OK"* ]]
+}
+
+# ─── wiring: doctor must actually run it ─────────────────────────────────────
+
+@test "doctor: reports verify-workflow pass on the canonical workflow" {
+    install_workflow enforced-canonical.yml
+    run node "$AAHP" doctor "$TEST_TMPDIR" --governance --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"verify-workflow": "pass"'* ]]
+}
+
+@test "doctor: FAILS the conformance record when the gate can be skipped" {
+    install_workflow bypass-step-conditional.yml
+    run node "$AAHP" doctor "$TEST_TMPDIR" --governance
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Conformance FAILED"* ]]
+    [[ "$output" == *"verify-workflow"* ]]
+}
+
+@test "doctor: an undecidable verify workflow fails closed, it does not skip" {
+    install_workflow undecidable-indirect.yml
+    run node "$AAHP" doctor "$TEST_TMPDIR" --governance --json
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"verify-workflow": "fail"'* ]]
+}
+
+@test "doctor: a repo with no workflows skips the gate rather than failing it" {
+    run node "$AAHP" doctor "$TEST_TMPDIR" --governance --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"verify-workflow": "skip"'* ]]
+}
+
+@test "doctor: AAHP's own workflow passes its own gate (dogfood)" {
+    run node "$AAHP" doctor "$AAHP_ROOT" --json
+    [[ "$output" == *'"verify-workflow": "pass"'* ]]
+}


### PR DESCRIPTION
## The defect this closes

`aahp-verify` is meant to be a REQUIRED status check. Wrap the job in an `if:`, or wrap the gate step inside it, and the check keeps its name, keeps being required, and keeps reporting **success while it evaluates nothing**. Branch protection is then satisfied by a verdict nobody produced. It is not only the Layer 2 drift gate that goes missing: **Layer 1 MANIFEST checksum integrity is skipped with it**.

AAHP could not see this from inside itself. The workflow AAHP ships is unconditional, `propagate.sh` copies it verbatim, and the weakening only ever exists in the consumer's copy. So the fix is not a change to the workflow: it is a check that runs INSIDE a consumer and reports that the workflow hosting the gate can skip the gate.

`aahp doctor` now audits the consumer's own `.github/workflows/`. Because the canonical workflow's last step runs `aahp doctor`, a repository that has weakened its gate now says so on its own pull requests. Shipped once, it reports everywhere.

## What is asserted

The **consequence**, not the file's shape: *there exists an event on which this workflow concludes success without having run the gate at `--level ci`*.

| Finding | The state it can reach |
|---------|------------------------|
| `job-conditional` | the hosting job carries an `if:`; when false the job is skipped and the required check is satisfied having run nothing |
| `job-soft-failing` | the job sets `continue-on-error`, so it reports success when the gate fails |
| `ci-step-conditional` | no step runs the gate at `--level ci` unconditionally, so on some events the job succeeds having verified nothing |
| `ci-step-soft-failing` | the gate runs unconditionally and its result is discarded |
| `no-ci-level` | the gate never runs at `--level ci`, so `AAHP_SKIP_VERIFY=1` is honoured and a workflow-level `env:` can set it |

Both other outcomes are deliberate. A repository whose workflows never run the gate reports `skip` (there is no backstop to weaken). A workflow that clearly hosts the gate but whose shape cannot be decided reports `fail` and exits 2, because **undecided is not clean**.

Two shapes are deliberately NOT findings, because they fail CLOSED rather than green: an `if:` on the checkout step alone (the gate then runs against an empty workspace and exits non-zero), and `paths:` filters that stop the workflow triggering (a required check that never reports leaves the pull request pending). Both are pinned by a test (`enforced-fails-closed-shapes.yml`), not only described here: a documented-but-untested exemption is precisely how the defect this gate exists for got in.

## Verified against real consumers, both directions

Per the rule that an AAHP change is verified against a real consumer, this was run against **every consumer of the protocol** before shipping, from a fresh read-only clone of each, and then again from the packed npm tarball:

| Repository | Verdict | Finding |
|---|---|---|
| `elvatis-security-platform` | bypassable | `ci-step-conditional` |
| `elvatis-intelligence` | bypassable | `ci-step-conditional` |
| `elvatis-defense` | bypassable | `ci-step-conditional` |
| `elvatis-client-portal` | bypassable | `ci-step-conditional` |
| `elvatis-trust` | bypassable | `ci-step-conditional` |
| `elvatis-sso` | bypassable | `ci-step-conditional` x2 (two workflows host the gate) |
| `atlas` | **enforced** | - |
| `elvatis-awareness` | **enforced** | - |
| this repository | **enforced** | - |

The enforced rows are what make the failing rows mean something: `atlas` and `elvatis-awareness` are the two consumers that already removed the bypass, and they come back clean.

Two corrections to what this repository previously recorded, both measured rather than recalled:

- The count was **six**, not five. `elvatis-trust` was recorded in `STATUS.md` as already corrected and is only PARTLY so. Its checkout IS unconditional and a bot change DOES get a Layer 1 run, but `--level ci` is still gated on the author, so one required check name means all four layers for one author and Layer 1 for another. `STATUS.md` is corrected in this branch.
- `elvatis-sso` runs the gate in **two** workflows, `aahp-verify.yml` and `ci.yml`, and both are conditional. The detector anchors on the INVOCATION rather than on a file name or job id, which is why the second one was found at all.

None of those repositories is touched by this pull request. Only their owners can re-propagate.

## The parser, and why it is held against a real one

AAHP ships no runtime dependencies, so the gate carries a small block-YAML reader instead of importing one. A hand-written parser that quietly disagrees with real YAML is the worst possible engine for a security gate: it would report `enforced` on a workflow it misread.

`tests/assert-workflow-parser-parity.mjs` therefore compares that reader against the real `yaml` package (a devDependency, so it never reaches a consumer) on every workflow in this repository and every fixture, on exactly the fields the audit consumes AND on the resulting finding ids. During development it was also run across **76 workflow files in 9 repositories**, and it earned its place twice:

- it caught that `npx -y @scope/aahp@3.10.0 verify . --level ci` did not match the invocation pattern, which had reported two live consumers as undecidable instead of naming their bypass;
- it caught that folded (`>`) block scalars do not fold a more-indented line, which is exactly how a wrapped `if:` is written.

## Mutation proof

Fix committed first, then each mutation applied by a script that ASSERTS the substitution changed the file (a substitution that silently matches nothing is a green run proving the opposite), the affected tests run, and the tree restored from the commit:

| Mutation | Result |
|---|---|
| detector stops treating a step-level `if:` as a bypass | `bypassable: a step-level if:` goes red |
| `verify-workflow` removed from the doctor gate set | 5 doctor tests go red |
| YAML reader folds every `>` line with a space | parser-parity test goes red |
| `unclassifiable` reports clean instead of failing closed | 3 undecidable tests go red |

## Test status

- `tests/verify-workflow.bats` 21/21, `tests/doctor.bats` 16/16, `tests/propagate.bats` 2/2, `npm run check` clean, `aahp doctor` clean, `aahp verify --level ci` clean against this branch's base.
- The full Bats suite is deliberately NOT run on this Windows machine; **the hosted Linux CI run on this pull request is the authoritative full-suite verdict, and passing it is a precondition for merging.**
- Packaging was checked from the packed tarball, not only the checkout, because `bin/aahp.js` gained an import: `scripts/check-verify-workflow.mjs` is present in `elvatis_com-aahp-3.10.0.tgz` and the CLI runs from it against a real consumer in both directions.

## Acceptance criteria

- [ ] `aahp doctor` reports a `verify-workflow` gate whose status distinguishes enforced, bypassable, absent and undecidable.
- [ ] A job-level `if:`, a step-level `if:` on the only `--level ci` step, `continue-on-error` on job or step, and a gate that never runs at `--level ci` are each reported as a finding and exit non-zero.
- [ ] A workflow that hosts the gate but cannot be classified exits 2 and reports `fail`; it never exits 0.
- [ ] A repository with no workflow running the gate reports `skip`, not `fail`.
- [ ] An `if:` on a job that does not host the gate produces no finding.
- [ ] `paths:` filters and a checkout-only `if:` produce no finding, and a test holds that exemption in place.
- [ ] The block-YAML reader agrees with a real YAML parser on every workflow and fixture in this repository, on the audited fields and on the resulting findings.
- [ ] The gate ships in the npm artifact and runs from an installed CLI.
- [ ] Hosted Linux CI is green on this pull request.

## For the owner

Merging this makes the six consumers listed above go RED on `aahp doctor` once they upgrade to a version carrying this gate. That is the intended forcing function, and it is worth naming explicitly: the alternative is six required checks that keep reporting a verdict nobody produced. Each consumer is fixed the same way `atlas` and `elvatis-awareness` already were, by moving the exemption INSIDE the gate, keyed on the change, instead of around the step, keyed on who pushed it.
