### PR TITLE
fix(ci): pin the schema-validation toolchain and gate it so pinning cannot lapse

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,9 +11,9 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:8b1cadab8156bc712469082d07caea6a7d0e1041b2ebfd3eb1f82dba2bc980a8",
-      "updated": "2026-08-22T22:39:02Z",
-      "lines": 167,
+      "checksum": "sha256:19a9521e54e74a7b944aa926d2b3d83f37a80fac9faf7b894876d7f09b9a582d",
+      "updated": "2026-08-22T22:43:01Z",
+      "lines": 187,
       "summary": "`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by"
     },
     "NEXT_ACTIONS.md": {
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 5544,
-    "full_read": 15614
+    "manifest_plus_core": 6255,
+    "full_read": 16325
   },
   "next_task_id": 18,
   "tasks": {

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,8 +11,8 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:19a9521e54e74a7b944aa926d2b3d83f37a80fac9faf7b894876d7f09b9a582d",
-      "updated": "2026-08-22T22:43:01Z",
+      "checksum": "sha256:964d4783aa4d99a908f638d67b4d4bada4447db8e3282aaa042866c667f57c90",
+      "updated": "2026-08-22T22:43:10Z",
       "lines": 187,
       "summary": "`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by"
     },

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -120,7 +120,7 @@ workflows that only ever ran here did not, because nothing made them.
 | `tests/verify-workflow.bats` | FOCUSED PASS | 21/21; both directions, the two fail-closed shapes that must NOT be findings, plus parser parity against a real YAML parser on 16 workflow files |
 | `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, runtime support, workflow pinning, and handoff freshness |
 | `tests/runtime-support.bats` | FOCUSED PASS | 16/16; the relation holds on this repo and each of nine mutations turns it red, including the emptied-matrix trap |
-| `tests/workflow-pinning.bats` | FOCUSED PASS | 18/18; every rule holds on this repository and each way of breaking one turns the gate red at the exact documented exit code, 1 for a finding and 2 for a state it cannot evaluate |
+| `tests/workflow-pinning.bats` | FOCUSED PASS | 19/19; every rule holds on this repository and each way of breaking one turns the gate red at the exact documented exit code, 1 for a finding and 2 for a state it cannot evaluate |
 | shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |
 | hosted Linux suite | REPLACEMENT REQUIRED | `c332a23` passed 361/362; the CI mode fixture let `git add` restore mode 100644 on Linux, so it now reasserts 100755 before its content-plus-mode commit |
 | `tests/doctor.bats` (3 new tests) | FOCUSED PASS | the three content-drift tests pass under Git Bash; two were mutated red and restored green. The other 16 tests in the file were not run on Windows; Linux CI is authoritative |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -89,6 +89,19 @@ do not, and those three are the invocations consumers wire into CI and hooks, so
 README also names the one configuration where the split has consequences for an
 adopter: `verify-workflow` reporting `skip` while the handoff gates are evaluated
 means no automated gate in that repository compares a handoff checksum.
+Separately, the two required status checks that validate `MANIFEST.json` no longer
+download and execute unpinned third-party code. `lint-and-validate` and
+`aahp-manifest` ran `npm install --no-save ajv-cli ajv-formats` and executed the
+result on the next line, on every push and every pull request, so 27 packages
+arrived with nothing in this repository constraining any of them and one
+compromised release anywhere in that closure was arbitrary code execution inside
+the checks whose verdict certifies a change. Both packages are now exact
+devDependencies locked by integrity hash, both jobs install that closure with
+`npm ci`, and both invoke the tool with `npx --no-install`. The root cause was not
+the forgotten pin: the workflow template this package ships to consumers
+(`assets/governance/aahp-govern.yml`) has always used the correct form, and the
+workflows that only ever ran here did not, because nothing made them.
+`check:workflow-pinning` is that something.
 <!-- /SECTION: summary -->
 
 ---
@@ -105,8 +118,9 @@ means no automated gate in that repository compares a handoff checksum.
 | schema validation | FOCUSED PASS | example and repository config both validate against the updated schema |
 | shell syntax | FOCUSED PASS | changed shell scripts parse under Git Bash |
 | `tests/verify-workflow.bats` | FOCUSED PASS | 21/21; both directions, the two fail-closed shapes that must NOT be findings, plus parser parity against a real YAML parser on 16 workflow files |
-| `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, runtime support, and handoff freshness |
+| `npm run check` | PASS | changelog, version sync, claims, forbidden patterns, schema/doc sync, doc links, runtime support, workflow pinning, and handoff freshness |
 | `tests/runtime-support.bats` | FOCUSED PASS | 16/16; the relation holds on this repo and each of nine mutations turns it red, including the emptied-matrix trap |
+| `tests/workflow-pinning.bats` | FOCUSED PASS | 18/18; every rule holds on this repository and each way of breaking one turns the gate red at the exact documented exit code, 1 for a finding and 2 for a state it cannot evaluate |
 | shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |
 | hosted Linux suite | REPLACEMENT REQUIRED | `c332a23` passed 361/362; the CI mode fixture let `git add` restore mode 100644 on Linux, so it now reasserts 100755 before its content-plus-mode commit |
 | `tests/doctor.bats` (3 new tests) | FOCUSED PASS | the three content-drift tests pass under Git Bash; two were mutated red and restored green. The other 16 tests in the file were not run on Windows; Linux CI is authoritative |
@@ -136,6 +150,9 @@ means no automated gate in that repository compares a handoff checksum.
 | verify-workflow gate | `scripts/check-verify-workflow.mjs` | New | audits the consumer's workflows for a gate that can skip itself; zero runtime dependencies, so it carries its own block-YAML reader, held against a real parser by `tests/assert-workflow-parser-parity.mjs` |
 | Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, workflow included in npm artifact, not released; `engines.node` now `>=22`, `yaml` added as a devDependency |
 | Repo-shape assertion | `tests/assert-repo-ci-shape.mjs` | Changed | third assertion: `publish` and `release` share ONE release definition, and every publish operand beyond it is recorded literally; reads the parsed condition, runs inside the required `lint-and-validate` |
+| Workflow-pinning gate | `scripts/check-workflow-pinning.mjs` | New | no project-level `npm install` in a workflow, every `npx` carries `--no-install`, every package a workflow executes is declared here at an exact version, every direct dependency is locked with `resolved` and `integrity`; exits 2 on a state it cannot evaluate |
+| Schema validation steps | `.github/workflows/ci.yml`, `.github/workflows/aahp-manifest.yml` | Changed | install the locked closure and run `ajv-cli` with `npx --no-install` instead of installing two undeclared packages from the registry on every run |
+| Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, workflow included in npm artifact, not released; `engines.node` now `>=22`, `yaml` added as a devDependency, `ajv-cli` 5.0.0 and `ajv-formats` 3.0.1 pinned exactly |
 <!-- /SECTION: components -->
 
 ---
@@ -154,6 +171,9 @@ means no automated gate in that repository compares a handoff checksum.
 | SemVer call for `engines.node` | NORMAL | Narrowing `>=18` to `>=22` is a support-surface reduction. Whether it ships inside 3.10.0 or forces 4.0.0 is an owner decision, not one this branch takes. |
 | `aahp-verify` can skip itself in six consumers | HIGH | ORIGINATED HERE. `458dbbd` (2026-06-30) added the dependency-bot exemption to this repository's own reference workflow, gating Checkout and every gate step; it shipped that way in v3.6.0 and propagated. `#65` removed it here on 2026-08-21. MEASURED 2026-08-22 with the new `verify-workflow` gate, against every consumer: six report `bypassable`, three report `enforced`. Five of the six report success having checked out nothing, so Layer 1 never runs either. The sixth was previously recorded here as corrected and is only PARTLY so: its checkout is unconditional and a bot change does get a Layer 1 run, but `--level ci` is still gated on the author, so the same required check name means all four layers for one author and Layer 1 for another. Only the owning repositories can re-propagate; this branch cannot fix any of them. Consumer identities are tracked privately and deliberately not recorded in this public repository. |
 | No drift check between a consumer's propagated workflow and the installed package | PARTLY CLOSED | `aahp doctor` still never compares `.github/workflows/aahp-verify.yml` on disk against the one in the installed package, so a consumer can pin 3.10.0 and run the v3.6.0 workflow. The designed predicate this row asked for now exists for the case that matters: `verify-workflow` asks whether the hosting workflow can skip the gate, which tolerates deliberate divergence (a consumer may restructure the file freely) while catching the divergence that voids the check. General byte-level drift, for example an older action pin or a dropped `fetch-depth: 0`, is still unmeasured. |
+| `npm install -g npm@latest` in the publish job | HIGH | Left in place deliberately. It is the only unpinned install inside the job that holds `id-token: write` immediately before `npm publish --provenance`, and it is a different risk class from the `ajv` path: the supplier is the package manager itself. The open question is whether the step should be DELETED rather than pinned, because its comment asserts that OIDC trusted publishing needs npm >= 12 while the pinned Node 24 line already ships npm 11.12.1, and that assertion is unverified. Owner decision, tracked at https://github.com/homeofe/AAHP/issues/68. The pinning gate names this exclusion in its header rather than hiding it in an exemption list. |
+| No dependency-scanning workflow | HIGH | No workflow here performs a dependency or supply-chain scan, and `.github/dependabot.yml` has no `github-actions` ecosystem entry. Which scanner to adopt, and whether to make it a seventh required status check, is an owner decision: adding a required context blocks every pull request until the check reports at least once. Tracked at https://github.com/homeofe/AAHP/issues/68. |
+| `ajv-cli` depends on `fast-json-patch` 2.2.1 | MEDIUM | GHSA-8gh8-hqwg-xf34, prototype pollution, fixed in 3.1.1. `ajv-cli` 5.0.0 requires `^2.0.0`, so the advisory cannot be resolved without an `overrides` entry that crosses a major version of a transitive dependency. This exposure is not new: the same closure was already being downloaded and executed on every CI run. Declaring the packages is what made it visible to `npm audit` and to Dependabot. |
 | Consumer manifests already rewritten | MEDIUM | The generator no longer writes a checkout's directory name into `project`, but repositories whose committed `MANIFEST.json` already carries such a name keep it, because a recorded name is preserved by design. Those values need correcting in the consumer repositories. |
 | Manual publish path on the `ci.yml` `publish` job | NORMAL | OPEN OWNER DECISION, deliberately not taken here. The publish condition still accepts `workflow_dispatch`, which constrains no ref, so a manual run publishes from whichever ref it started on with no tag and no GitHub Release. Options A, B and C, and what each one requires, are in ADR-019. The condition is now pinned, so adopting any of them is a visible two-part edit rather than a silent one. |
 <!-- /SECTION: what_is_missing -->

--- a/.github/workflows/aahp-manifest.yml
+++ b/.github/workflows/aahp-manifest.yml
@@ -23,10 +23,16 @@ jobs:
           python-version: '3.x'
       - name: Validate MANIFEST JSON
         run: python -m json.tool .ai/handoff/MANIFEST.json > /dev/null
+      # This job runs no other npm step, so it installs the locked closure
+      # itself. --ignore-scripts because nothing here needs a lifecycle hook
+      # to run, and the whole point of the step is to execute less foreign code.
+      - name: Install pinned dependencies
+        run: npm ci --ignore-scripts
       - name: Validate MANIFEST schema
-        run: |
-          npm install --no-save ajv-cli ajv-formats
-          npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
+        # `--no-install` is the load-bearing half: without it npx falls back to
+        # the registry whenever the local resolution misses, and the pin above
+        # buys nothing. scripts/check-workflow-pinning.mjs keeps this shape.
+        run: npx --no-install ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
       - name: Check MANIFEST generator
         run: |
           tmpdir="$(mktemp -d)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,13 @@ jobs:
         run: bash scripts/lint-handoff.sh .
 
       - name: Validate MANIFEST.json against schema
-        run: |
-          npm install --no-save ajv-cli ajv-formats
-          npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
+        # ajv-cli and ajv-formats are exact devDependencies, so the `npm ci`
+        # step above already installed the locked closure and there is nothing
+        # left to fetch here. `--no-install` is the load-bearing half: without
+        # it npx falls back to the registry whenever the local resolution
+        # misses, and the pin upstream buys nothing.
+        # scripts/check-workflow-pinning.mjs keeps this shape.
+        run: npx --no-install ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
 
       - name: Syntax-check Node gates
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,40 @@ independently of the npm version).
   lives in a tracked config file in this public repository and would then publish the one
   identity this change exists to withhold.
 
+### Security
+- The two required status checks that validate `MANIFEST.json` no longer download
+  and execute unpinned third-party code. `lint-and-validate` and `aahp-manifest`
+  ran `npm install --no-save ajv-cli ajv-formats` and executed the result on the
+  next line, on every push and every pull request. `--no-save` guarantees the
+  resolution is never written to `package-lock.json`, so 27 packages arrived with
+  nothing in the repository constraining any of them, and one compromised release
+  anywhere in that closure was arbitrary code execution inside the checks whose
+  verdict certifies a change. `ajv-cli` (5.0.0) and `ajv-formats` (3.0.1) are now
+  exact devDependencies locked by integrity hash, both jobs install that locked
+  closure with `npm ci`, and both invoke the tool with `npx --no-install`. The
+  `--no-install` is the load-bearing half: without it npx falls back to the
+  registry whenever the local resolution misses, and the pin buys nothing.
+- `npm run check:workflow-pinning` is why it stays that way. The root cause was
+  not a forgotten pin, it was that pinning here was a hand-applied convention:
+  the workflow template this package ships to consumers
+  (`assets/governance/aahp-govern.yml`) has always used `npm ci --ignore-scripts`
+  followed by `npx --no-install`, and the workflows that only ever ran here did
+  not, because nothing made them. The gate asserts four properties over every
+  workflow in `.github/workflows` and every template in `assets/governance`: no
+  project-level `npm install`, every `npx` carries `--no-install`, every package a
+  workflow executes is declared here at an exact version, and every direct
+  dependency carries both `resolved` and `integrity` in the lockfile. A state it
+  cannot evaluate exits 2 rather than 0, so "I could not look" never reads as
+  "I looked and it was fine". Deliberately out of scope and named rather than
+  quietly exempted: `npm install -g` in the publish job, a different risk class
+  with an owner decision still open on it, tracked at
+  https://github.com/homeofe/AAHP/issues/68.
+- Three schema tests stop failing open. The two in `tests/handoff-impact.bats` and
+  the one in `tests/init-gates.bats` skip when `ajv-cli` cannot be resolved, so
+  they only ever ran in the one job that happened to have installed it and
+  reported "# skip ajv-cli not installed" everywhere else while the check stayed
+  green. Declaring the package means `npm ci` installs it and the tests execute.
+
 ## [3.10.0] - 2026-08-20
 **Fail-closed Layer 2 base selection and reviewed exact-file impact classification**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,13 @@ independently of the npm version).
   they only ever ran in the one job that happened to have installed it and
   reported "# skip ajv-cli not installed" everywhere else while the check stayed
   green. Declaring the package means `npm ci` installs it and the tests execute.
+- The version regex in the new gate is not exponentially ambiguous. Its first form
+  repeated a group whose character class also contained the group's own delimiter,
+  which CodeQL reported as `js/redos`. Measured on the input shape it named,
+  `9.9.9+` followed by repeated `--`: 22 repetitions, a 51-character string, took
+  11.8 seconds under the old form and 0.004 ms under the replacement. The input is
+  a `package.json` version specifier, which is attacker-supplied on a fork pull
+  request. What counts as an exact version is unchanged.
 
 ## [3.10.0] - 2026-08-20
 **Fail-closed Layer 2 base selection and reviewed exact-file impact classification**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,18 @@ independently of the npm version).
   `9.9.9+` followed by repeated `--`: 22 repetitions, a 51-character string, took
   11.8 seconds under the old form and 0.004 ms under the replacement. The input is
   a `package.json` version specifier, which is attacker-supplied on a fork pull
-  request. What counts as an exact version is unchanged.
+  request. What counts as an exact version did narrow, in exactly one place: the
+  replacement's build class is `[0-9A-Za-z.]`, which drops the `-` the prerelease
+  class still allows, so a SemVer-legal version whose build metadata contains a
+  hyphen is now reported as a range. Measured old form against new,
+  `1.0.0+21AF26D3----117B344092BD` (the SemVer specification's own example),
+  `1.2.3+build-5`, `1.2.3-alpha+a-b`, `1.2.3-x+y-z` and `0.0.4+-` all went from
+  accepted to rejected. The narrowing runs fail-closed - nothing unpinned became
+  acceptable, a legal pin became unacceptable - and it is unreachable for the two
+  packages this gate governs, both pinned without build metadata. It is still a
+  false positive, and the finding it prints ("Declare an exact version") misnames
+  the cause, so if it is ever hit the fix is to put the hyphen back in the build
+  class, which stays linear because `+` cannot appear inside it.
 
 ## [3.10.0] - 2026-08-20
 **Fail-closed Layer 2 base selection and reviewed exact-file impact classification**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,11 @@ npx bats tests/migrate.bats
 # Lint handoff files
 bash scripts/lint-handoff.sh .
 
-# Schema validation (install deps first)
-npm install --no-save ajv-cli ajv-formats
-npx ajv-cli validate --spec=draft2020 -c ajv-formats \
+# Schema validation. ajv-cli and ajv-formats are pinned devDependencies, so
+# `npm ci` installs them from the lockfile and --no-install keeps npx off the
+# registry. scripts/check-workflow-pinning.mjs goes red if this drifts back.
+npm ci
+npx --no-install ajv-cli validate --spec=draft2020 -c ajv-formats \
   -s schema/aahp-manifest.schema.json \
   -d .ai/handoff/MANIFEST.json
 

--- a/README.md
+++ b/README.md
@@ -202,12 +202,22 @@ The exit code is therefore safe to wire into a hook or a CI job. `aahp verify`
 Layer 1 computes its integrity verdicts itself, so blocking never depends on
 that exit code either.
 
-To use AJV for strict schema validation in CI, install it separately:
+To use AJV for strict schema validation in CI, declare it as an exact
+devDependency and run it from your lockfile rather than from the registry:
 
 ```bash
-# Optional: strict AJV validation in CI
-npx ajv validate -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
+# once, and commit the resulting package-lock.json
+npm i -D -E ajv-cli ajv-formats
+
+# in CI
+npm ci --ignore-scripts
+npx --no-install ajv-cli validate --spec=draft2020 -c ajv-formats \
+  -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
 ```
+
+`--no-install` is what makes the pin load-bearing. Without it `npx` falls back to
+fetching from the registry whenever the local resolution misses, so the version
+that executes is whatever the registry serves at that moment.
 
 If the manifest doesn't conform, the pipeline rejects the commit. This prevents malformed handoffs from entering the repo.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,93 @@
         "aahp": "bin/aahp.js"
       },
       "devDependencies": {
+        "ajv-cli": "5.0.0",
+        "ajv-formats": "3.0.1",
         "bats": "^1.13.0",
         "yaml": "2.9.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ajv": "dist/index.js"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bats": {
       "version": "1.13.0",
@@ -28,6 +109,241 @@
       "bin": {
         "bats": "bin/bats"
       }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -52,15 +52,18 @@
     "check:schema-doc-sync": "node scripts/check-schema-doc-sync.mjs",
     "check:doc-links": "node scripts/check-doc-links.mjs",
     "check:runtime-support": "node scripts/check-runtime-support.mjs",
+    "check:workflow-pinning": "node scripts/check-workflow-pinning.mjs",
     "check:handoff": "node scripts/aahp-dashboard.mjs --check",
     "handoff:refresh": "node scripts/aahp-dashboard.mjs",
-    "check": "npm run check:changelog && npm run check:changelog-format && npm run check:version-sync && npm run check:claims && npm run check:forbidden-patterns && npm run check:schema-doc-sync && npm run check:doc-links && npm run check:runtime-support && npm run check:handoff",
+    "check": "npm run check:changelog && npm run check:changelog-format && npm run check:version-sync && npm run check:claims && npm run check:forbidden-patterns && npm run check:schema-doc-sync && npm run check:doc-links && npm run check:runtime-support && npm run check:workflow-pinning && npm run check:handoff",
     "criteria": "node bin/aahp.js criteria .",
     "doctor": "node bin/aahp.js doctor .",
     "test": "npx bats tests/",
     "prepublishOnly": "npm run check && npm run doctor && npm test"
   },
   "devDependencies": {
+    "ajv-cli": "5.0.0",
+    "ajv-formats": "3.0.1",
     "bats": "^1.13.0",
     "yaml": "2.9.0"
   }

--- a/scripts/check-workflow-pinning.mjs
+++ b/scripts/check-workflow-pinning.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+// check-workflow-pinning.mjs - Whatever a workflow installs and then executes
+// must come from the committed lockfile, and the lockfile must pin it by hash.
+//
+// WHY THIS GATE EXISTS
+// ---------------------------------------------------------------------------
+// Measured 2026-08-22. Two of the six required status checks on `main` ran
+//
+//     npm install --no-save ajv-cli ajv-formats
+//     npx ajv-cli validate ... .ai/handoff/MANIFEST.json
+//
+// on every push and every pull request. `--no-save` guarantees the resolution
+// is never written to package-lock.json, so 27 packages were downloaded and
+// executed with nothing in the repository constraining any of them, and the
+// next line executed the result by design. One compromised release anywhere in
+// that closure was arbitrary code execution inside the checks whose verdict
+// certifies a change. This repository publishes those gates for other
+// repositories to install and trust, so the failure propagated outward.
+//
+// The packages are pinned now. This gate is why they stay pinned.
+//
+// THE ROOT CAUSE IS NOT "SOMEONE FORGOT TO PIN"
+// ---------------------------------------------------------------------------
+// The repository already knew how to do this correctly and already documented
+// it. assets/governance/aahp-govern.yml - the workflow template this package
+// ships to consumers - has always used `npm ci --ignore-scripts` followed by
+// `npx --no-install`, and .github/workflows/aahp-verify.yml pins its actions to
+// full commit SHAs. Both are files strangers read. The workflows that only ever
+// ran here did not follow the same rule, because nothing made them.
+//
+// So the defect was not the missing pin, it was that pinning was a convention
+// applied by hand where it would be seen. A convention has no failure mode: it
+// simply stops being applied, silently, the first time someone rewrites a file.
+// This gate turns it into a property of the repository, which does have one.
+//
+// WHAT IS ASSERTED, AND THE MUTATION THAT TURNS EACH ONE RED
+// ---------------------------------------------------------------------------
+//   A. No workflow performs a project-level `npm install` / `npm i` / `npm add`.
+//      The reproducible form is `npm ci`, which installs the locked closure and
+//      nothing else. MUTATION: put `npm install --no-save ajv-cli ajv-formats`
+//      back into any scanned workflow.
+//
+//   B. Every `npx` in a workflow carries `--no-install`. This is the load
+//      bearing half, and leaving it out is the failure that looks fixed:
+//      without `--no-install`, npx silently falls back to fetching from the
+//      registry whenever the local resolution misses, and the pin buys nothing.
+//      MUTATION: drop `--no-install` from either validate step.
+//
+//   C. Every package a workflow executes with `npx --no-install` is declared in
+//      package.json at an EXACT version. A range is reproducible through the
+//      lockfile but not reviewable in the diff, which is where a supply-chain
+//      change has to be visible. MUTATION: change "ajv-cli": "5.0.0" to
+//      "^5.0.0", or remove the declaration entirely.
+//      Asked only of workflows that run HERE, not of the shipped templates:
+//      a template runs against a CONSUMER package.json, so this one is not
+//      the file that declares its npx target.
+//
+//   D. Every direct dependency and devDependency has a package-lock.json entry
+//      carrying both `resolved` and `integrity`. This is the "by hash" half: a
+//      declaration alone says which version, the lockfile says which BYTES.
+//      MUTATION: delete the `integrity` field from any locked direct dependency.
+//
+// DELIBERATELY OUT OF SCOPE, so the hole is visible here rather than invisible
+// in CI: `npm install -g <pkg>` (ci.yml, publish job). It is a different risk
+// class - the package manager itself, published by the registry operator,
+// inside the only job holding `id-token: write` - and there is an open owner
+// decision on whether that step should exist at all rather than be pinned. See
+// https://github.com/homeofe/AAHP/issues/68. Extending this gate to global
+// installs is a few lines once that decision lands. It is named here instead of
+// being quietly allowed by an exemption list that nobody would ever re-read.
+//
+// WHICH FILES ARE SCANNED
+// ---------------------------------------------------------------------------
+// .github/workflows (what runs here) and assets/governance (workflow templates
+// consumers copy into their own .github/workflows). Both are files that execute
+// on somebody's CI. tests/fixtures/workflows is NOT scanned: those files are
+// deliberately malformed inputs to another gate's tests.
+//
+// EXIT CODES
+//   0  every rule holds across every scanned file
+//   1  a rule is violated - a real finding
+//   2  the gate could not evaluate (no YAML parser, no workflow directory, no
+//      workflow files, unparseable workflow, unreadable package.json or
+//      package-lock.json). Never 0: "I could not look" must not read as
+//      "I looked and it was fine".
+//
+// DELIBERATELY NOT IN bin/aahp.js CHECK_GATES
+// ---------------------------------------------------------------------------
+// The gates in CHECK_GATES run against an arbitrary CONSUMER project via
+// `aahp check`. Turning this one on there would go red on the first run in most
+// consumer repositories, which is a fleet-wide breaking change and an owner
+// decision, not a side effect of fixing this repository. It is wired into
+// `npm run check` instead, which is what the required lint-and-validate job
+// executes, and tests/workflow-pinning.bats asserts that wiring so the gate
+// cannot quietly stop being invoked.
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { resolveRoot, loadPkg } from "./aahp-config.mjs";
+
+// Directories whose YAML files are workflows. The first is required to exist
+// and to be non-empty; a missing optional directory is simply not scanned.
+const WORKFLOW_DIR = join(".github", "workflows");
+const TEMPLATE_DIRS = [join("assets", "governance")];
+
+// `npm install` and every alias npm accepts for it. `ci` is deliberately absent:
+// it is the form this gate exists to require.
+const INSTALL_VERBS = new Set(["install", "i", "in", "ins", "inst", "insta", "instal", "isntall", "add"]);
+
+// Flags that make an install global. Global installs are out of scope (header).
+const GLOBAL_FLAGS = /^(?:-g|--global|--location=global)$/;
+
+// An exact version: no caret, tilde, range, tag, URL or git ref.
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+
+const root = resolveRoot();
+
+function bail(code, lines) {
+  console.error("");
+  for (const line of lines) console.error(`  ${line}`);
+  console.error("");
+  process.exit(code);
+}
+
+let YAML;
+try {
+  YAML = await import("yaml");
+} catch {
+  bail(2, [
+    "Workflow pinning: no YAML parser available.",
+    "This gate parses workflow files with the `yaml` devDependency rather than",
+    "matching text, because a regex over YAML silently misreads block scalars,",
+    "anchors and quoting - and would then report a clean repository it never",
+    "actually read.",
+    "",
+    "Fix: run `npm ci` so devDependencies are present.",
+  ]);
+}
+
+let pkg;
+try {
+  pkg = loadPkg(root);
+} catch (err) {
+  bail(2, [`Workflow pinning: ${err.message}`]);
+}
+
+const lockPath = join(root, "package-lock.json");
+if (!existsSync(lockPath)) {
+  bail(2, [
+    `Workflow pinning: no package-lock.json at ${lockPath}.`,
+    "Without a lockfile there is nothing that pins anything by hash, so the",
+    "relation this gate asserts is untested rather than satisfied.",
+  ]);
+}
+let lock;
+try {
+  lock = JSON.parse(readFileSync(lockPath, "utf8"));
+} catch (err) {
+  bail(2, [`Workflow pinning: package-lock.json is not valid JSON (${err.message}).`]);
+}
+
+// ---------------------------------------------------------------------------
+// The files to scan.
+// ---------------------------------------------------------------------------
+function yamlFilesIn(relDir, { required }) {
+  const abs = join(root, relDir);
+  if (!existsSync(abs)) {
+    if (!required) return [];
+    bail(2, [
+      `Workflow pinning: no workflow directory at ${abs}.`,
+      "This gate asserts a property of the workflows that run here. With no",
+      "workflows there is nothing to assert it over, so the answer is unknown",
+      "rather than clean.",
+    ]);
+  }
+  const files = readdirSync(abs)
+    .filter((f) => /\.ya?ml$/.test(f))
+    .sort()
+    .map((f) => ({ rel: `${relDir.replace(/\\/g, "/")}/${f}`, abs: join(abs, f), local: required }));
+  if (required && files.length === 0) {
+    bail(2, [`Workflow pinning: ${abs} contains no workflow files.`]);
+  }
+  return files;
+}
+
+const scanned = [
+  ...yamlFilesIn(WORKFLOW_DIR, { required: true }),
+  ...TEMPLATE_DIRS.flatMap((d) => yamlFilesIn(d, { required: false })),
+];
+
+// ---------------------------------------------------------------------------
+// Shell-command extraction from a `run:` block.
+//
+// The block is split into individual commands so a violation cannot hide behind
+// a separator: `foo && npm install bar` is two commands, not one. Splitting can
+// only ever produce MORE fragments to inspect, never fewer, so an odd quoting
+// case costs a harmless extra fragment rather than a missed finding.
+// ---------------------------------------------------------------------------
+export function commandsIn(runText) {
+  const joined = String(runText).replace(/\\\r?\n/g, " ");
+  const commands = [];
+  for (const rawLine of joined.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    for (const part of line.split(/(?:&&|\|\||[|;])/)) {
+      const cmd = part.trim();
+      if (cmd !== "") commands.push(cmd);
+    }
+  }
+  return commands;
+}
+
+function tokenize(command) {
+  return command.split(/\s+/).filter((t) => t !== "");
+}
+
+// The package npx is asked to run: the first argument that is not a flag and is
+// not the value consumed by a flag that takes one.
+export function npxTarget(tokens) {
+  for (let i = 1; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === "-p" || t === "--package" || t === "-c" || t === "--call") {
+      i++;
+      continue;
+    }
+    if (t.startsWith("-")) continue;
+    return t;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Rules A, B and C, over every `run:` in every scanned workflow.
+// ---------------------------------------------------------------------------
+const findings = [];
+const npxTargets = [];
+
+function parseWorkflow(file) {
+  let text;
+  try {
+    text = readFileSync(file.abs, "utf8");
+  } catch (err) {
+    bail(2, [`Workflow pinning: cannot read ${file.rel} (${err.message}).`]);
+  }
+  try {
+    return YAML.parse(text) ?? {};
+  } catch (err) {
+    bail(2, [
+      `Workflow pinning: ${file.rel} is not valid YAML (${err.message}).`,
+      "The gate refuses to guess at a file it cannot parse.",
+    ]);
+  }
+}
+
+for (const file of scanned) {
+  const doc = parseWorkflow(file);
+  const jobs = doc?.jobs;
+  if (!jobs || typeof jobs !== "object") continue;
+
+  for (const [jobName, job] of Object.entries(jobs)) {
+    const steps = Array.isArray(job?.steps) ? job.steps : [];
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      if (typeof step?.run !== "string") continue;
+      const where = `${file.rel}:${jobName}:${step.name || `step ${i + 1}`}`;
+
+      for (const command of commandsIn(step.run)) {
+        const tokens = tokenize(command);
+        if (tokens.length === 0) continue;
+
+        if (tokens[0] === "npm" && INSTALL_VERBS.has(tokens[1] ?? "")) {
+          if (tokens.some((t) => GLOBAL_FLAGS.test(t))) continue; // out of scope, see header
+          findings.push({
+            where,
+            command,
+            message:
+              "installs packages outside the committed lockfile. Use `npm ci`, which " +
+              "installs exactly the locked closure. `--no-save` in particular guarantees " +
+              "the resolution is never recorded anywhere.",
+          });
+          continue;
+        }
+
+        if (tokens[0] === "npx") {
+          if (!tokens.includes("--no-install")) {
+            findings.push({
+              where,
+              command,
+              message:
+                "runs npx without `--no-install`, so npx falls back to fetching from the " +
+                "registry whenever the local resolution misses. Any pin upstream of this " +
+                "line buys nothing while this line can reach the network.",
+            });
+            continue;
+          }
+          // Rule C is asked only of workflows that run HERE. A shipped
+          // template runs in a consumer repository against a consumer
+          // package.json, so this package.json is not the file that would
+          // declare its npx target - `aahp` itself being the obvious case.
+          const target = file.local ? npxTarget(tokens) : null;
+          if (target !== null) npxTargets.push({ target, where });
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule C: what npx executes must be declared here, at an exact version.
+// ---------------------------------------------------------------------------
+const declared = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+
+for (const { target, where } of npxTargets) {
+  const spec = declared[target];
+  if (spec === undefined) {
+    findings.push({
+      where,
+      command: `npx --no-install ${target}`,
+      message:
+        `executes "${target}", which package.json does not declare. Nothing in this ` +
+        "repository states which version that is, so nothing can pin it. Declare it as " +
+        "an exact devDependency and commit the regenerated package-lock.json.",
+    });
+    continue;
+  }
+  if (!EXACT_VERSION.test(spec)) {
+    findings.push({
+      where,
+      command: `npx --no-install ${target}`,
+      message:
+        `executes "${target}", declared as ${JSON.stringify(spec)}. A range resolves ` +
+        "through the lockfile but is not visible in the diff, which is where a " +
+        "supply-chain change has to be reviewable. Declare an exact version.",
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule D: the lockfile pins every direct dependency by hash.
+// ---------------------------------------------------------------------------
+const lockPackages = lock?.packages;
+if (!lockPackages || typeof lockPackages !== "object") {
+  bail(2, [
+    "Workflow pinning: package-lock.json has no `packages` map.",
+    `This gate reads lockfileVersion 2 or 3; this file reports ${JSON.stringify(lock?.lockfileVersion)}.`,
+    "It refuses to report a clean result over a shape it cannot read.",
+  ]);
+}
+
+for (const [name, spec] of Object.entries(declared)) {
+  const entry = lockPackages[`node_modules/${name}`];
+  if (!entry) {
+    findings.push({
+      where: "package-lock.json",
+      command: `${name}@${spec}`,
+      message:
+        "is declared in package.json but has no lockfile entry, so `npm ci` cannot " +
+        "install it and nothing pins its bytes. Run `npm install` and commit the lockfile.",
+    });
+    continue;
+  }
+  if (typeof entry.integrity !== "string" || entry.integrity === "") {
+    findings.push({
+      where: "package-lock.json",
+      command: `${name}@${entry.version ?? "?"}`,
+      message:
+        "has no `integrity` hash in the lockfile. The version says which release; the " +
+        "integrity hash says which bytes. Without it a republished tarball installs clean.",
+    });
+  }
+  if (typeof entry.resolved !== "string" || entry.resolved === "") {
+    findings.push({
+      where: "package-lock.json",
+      command: `${name}@${entry.version ?? "?"}`,
+      message: "has no `resolved` URL in the lockfile, so its origin is unrecorded.",
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+if (findings.length > 0) {
+  console.error(`\n  Workflow pinning failed (${findings.length} finding(s)).\n`);
+  for (const f of findings) {
+    console.error(`  - ${f.where}`);
+    console.error(`      ${f.command}`);
+    console.error(`      ${f.message}`);
+  }
+  console.error("");
+  process.exit(1);
+}
+
+console.log(
+  `Workflow pinning OK: ${scanned.length} workflow file(s), ` +
+    `${npxTargets.length} pinned npx invocation(s), ` +
+    `${Object.keys(declared).length} direct dependencies locked by hash.`,
+);
+for (const file of scanned) console.log(`    ${file.rel}`);

--- a/scripts/check-workflow-pinning.mjs
+++ b/scripts/check-workflow-pinning.mjs
@@ -111,7 +111,11 @@ const INSTALL_VERBS = new Set(["install", "i", "in", "ins", "inst", "insta", "in
 const GLOBAL_FLAGS = /^(?:-g|--global|--location=global)$/;
 
 // An exact version: no caret, tilde, range, tag, URL or git ref.
-const EXACT_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+// At most ONE prerelease run and at most ONE build run, deliberately: a
+// repeated group whose character class also contains its own delimiter is
+// exponentially ambiguous, and package.json is attacker-supplied on a fork
+// pull request. Reported by CodeQL js/redos against the earlier form.
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.]+)?$/;
 
 const root = resolveRoot();
 

--- a/tests/assert-pinning-gate-wired.mjs
+++ b/tests/assert-pinning-gate-wired.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// assert-pinning-gate-wired.mjs - repository-shape assertions for
+// workflow-pinning.bats.
+//
+// Kept as a file rather than inlined into `node -e` on purpose: under Git Bash
+// (MSYS) a POSIX-looking path INSIDE a quoted -e string is not converted for the
+// native node binary, so the repo root arrives mangled and the test reports a
+// defect that does not exist. A path passed as an argv element IS converted.
+// Same reasoning as tests/assert-repo-ci-shape.mjs.
+//
+// Two things are asserted, and neither is about the gate's own logic:
+//
+//   1. The workflow-pinning gate is actually INVOKED by the aggregate `check`
+//      chain, which is what the required lint-and-validate job runs. A gate that
+//      exists but never runs protects nothing, and nothing else in the
+//      repository would notice it had been dropped from the chain.
+//   2. The two packages the required checks execute are pinned the way the gate
+//      requires: declared at an exact version and locked with an integrity hash.
+//      The gate derives this from the workflow files; this derives it from the
+//      package names directly, so a change that stopped the gate from seeing
+//      those steps cannot also silence this.
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const root = resolve(process.argv[2] || ".");
+const problems = [];
+
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const lock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8"));
+
+if (!pkg.scripts?.["check:workflow-pinning"]) {
+  problems.push("package.json defines no check:workflow-pinning script");
+}
+if (!pkg.scripts?.check?.includes("check:workflow-pinning")) {
+  problems.push(
+    "check:workflow-pinning is not part of the aggregate `check` chain, which is " +
+      "what the required lint-and-validate job runs. The gate would never execute.",
+  );
+}
+
+// The packages the required lint-and-validate and aahp-manifest checks execute.
+const EXECUTED_IN_REQUIRED_CHECKS = ["ajv-cli", "ajv-formats"];
+const EXACT = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+
+for (const name of EXECUTED_IN_REQUIRED_CHECKS) {
+  const spec = pkg.devDependencies?.[name] ?? pkg.dependencies?.[name];
+  if (spec === undefined) {
+    problems.push(`${name} is executed by a required status check but is not declared in package.json`);
+    continue;
+  }
+  if (!EXACT.test(spec)) {
+    problems.push(`${name} is declared as ${JSON.stringify(spec)}, which is not an exact version`);
+  }
+  const entry = lock.packages?.[`node_modules/${name}`];
+  if (!entry) {
+    problems.push(`${name} has no package-lock.json entry, so npm ci cannot install it`);
+    continue;
+  }
+  if (typeof entry.integrity !== "string" || entry.integrity === "") {
+    problems.push(`${name} has no integrity hash in package-lock.json`);
+  }
+  if (entry.version !== spec) {
+    problems.push(`${name} is declared as ${spec} but locked at ${entry.version}`);
+  }
+}
+
+if (problems.length > 0) {
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log("pinning gate wiring OK");

--- a/tests/assert-pinning-gate-wired.mjs
+++ b/tests/assert-pinning-gate-wired.mjs
@@ -41,7 +41,7 @@ if (!pkg.scripts?.check?.includes("check:workflow-pinning")) {
 
 // The packages the required lint-and-validate and aahp-manifest checks execute.
 const EXECUTED_IN_REQUIRED_CHECKS = ["ajv-cli", "ajv-formats"];
-const EXACT = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+const EXACT = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.]+)?$/;
 
 for (const name of EXECUTED_IN_REQUIRED_CHECKS) {
   const spec = pkg.devDependencies?.[name] ?? pkg.dependencies?.[name];

--- a/tests/workflow-pinning.bats
+++ b/tests/workflow-pinning.bats
@@ -229,6 +229,20 @@ EOF
     [[ "$output" == *"Declare an exact version"* ]]
 }
 
+@test "an exact version carrying a prerelease and build suffix is accepted" {
+    # Guards the shape of the version regex, which was rewritten after CodeQL
+    # reported js/redos against the first form. A repeated group whose character
+    # class also contains its own delimiter is exponentially ambiguous, and
+    # package.json is attacker-supplied on a fork pull request. The rewrite must
+    # not have narrowed what counts as an exact version.
+    write_pkg '"fx-tool": "1.2.3-beta.1+build.5"'
+    write_lock '"version": "1.2.3-beta.1+build.5", "resolved": "https://registry.npmjs.org/fx-tool/-/fx-tool-1.2.3.tgz", "integrity": "sha512-deadbeef"'
+    write_good_workflow
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
 # ─── Rule D: the lockfile pins every direct dependency by hash ──────────────
 
 @test "a lockfile entry without an integrity hash is red" {

--- a/tests/workflow-pinning.bats
+++ b/tests/workflow-pinning.bats
@@ -233,8 +233,18 @@ EOF
     # Guards the shape of the version regex, which was rewritten after CodeQL
     # reported js/redos against the first form. A repeated group whose character
     # class also contains its own delimiter is exponentially ambiguous, and
-    # package.json is attacker-supplied on a fork pull request. The rewrite must
-    # not have narrowed what counts as an exact version.
+    # package.json is attacker-supplied on a fork pull request.
+    #
+    # The rewrite DID narrow what counts as an exact version, and this test
+    # cannot see it. The new build class is `[0-9A-Za-z.]`, which drops the `-`
+    # the prerelease class still allows, so build metadata containing a hyphen -
+    # `1.0.0+21AF26D3----117B344092BD`, the SemVer specification's own example -
+    # is now reported as a range. The fixture below carries `+build.5`, no
+    # hyphen, so it is green under both forms and proves only that a prerelease
+    # and a dot-separated build survive. The narrowing is fail-closed and
+    # unreachable for the two packages this gate governs; if it is ever hit, put
+    # the hyphen back in the build class (still linear, `+` cannot appear inside
+    # it) and add the hyphen case here.
     write_pkg '"fx-tool": "1.2.3-beta.1+build.5"'
     write_lock '"version": "1.2.3-beta.1+build.5", "resolved": "https://registry.npmjs.org/fx-tool/-/fx-tool-1.2.3.tgz", "integrity": "sha512-deadbeef"'
     write_good_workflow

--- a/tests/workflow-pinning.bats
+++ b/tests/workflow-pinning.bats
@@ -1,0 +1,306 @@
+#!/usr/bin/env bats
+# workflow-pinning.bats - whatever a workflow installs and then executes must
+# come from the committed lockfile, and the lockfile must pin it by hash.
+#
+# Every rule is asserted in BOTH directions: it holds on the real repository,
+# and each separate way of breaking it turns the gate red with the EXACT exit
+# code the gate documents. A gate proved only in the passing direction is
+# indistinguishable from a gate that cannot fail.
+#
+# Exit codes are compared with -eq, never with "not zero". Exit 1 (a finding)
+# and exit 2 (the gate could not evaluate) are different answers, and a mutation
+# that reaches the wrong one has not proved what the test claims.
+
+load test_helper
+
+GATE="$SCRIPTS_DIR/check-workflow-pinning.mjs"
+
+# NOTE: TEST_TMPDIR is created by setup(), which runs AFTER this file is sourced,
+# so the workflow directory cannot be a top-level variable - it would expand to
+# "/.github/workflows" here. Every test calls this instead.
+wf_dir() {
+    printf '%s/.github/workflows' "$TEST_TMPDIR"
+}
+
+# package.json for a fixture project. $1 is the devDependencies body; omitting it
+# declares the one package the baseline workflow executes, at an exact version.
+write_pkg() {
+    local deps="${1:-\"fx-tool\": \"1.2.3\"}"
+    cat > "$TEST_TMPDIR/package.json" <<EOF
+{ "name": "fx", "version": "1.0.0", "devDependencies": { $deps } }
+EOF
+}
+
+# package-lock.json for a fixture project. $1 is the packages body for the one
+# dependency; omitting it writes a complete, correctly pinned entry.
+write_lock() {
+    local entry="${1:-\"version\": \"1.2.3\", \"resolved\": \"https://registry.npmjs.org/fx-tool/-/fx-tool-1.2.3.tgz\", \"integrity\": \"sha512-deadbeef\"}"
+    cat > "$TEST_TMPDIR/package-lock.json" <<EOF
+{
+  "name": "fx",
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "name": "fx", "devDependencies": { "fx-tool": "1.2.3" } },
+    "node_modules/fx-tool": { $entry }
+  }
+}
+EOF
+}
+
+# The baseline fixture: install the locked closure, then execute a pinned tool
+# offline. Every mutation test below starts from this and breaks ONE thing, so a
+# red result can only have been caused by that one change.
+write_good_workflow() {
+    mkdir -p "$(wf_dir)"
+    cat > "$(wf_dir)/ci.yml" <<'EOF'
+name: fx
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Validate
+        run: npx --no-install fx-tool validate -s schema.json -d data.json
+EOF
+}
+
+# Everything a passing fixture needs, in one call.
+write_good_fixture() {
+    write_pkg
+    write_lock
+    write_good_workflow
+}
+
+# ─── The load-bearing assertion: the real repository ────────────────────────
+
+@test "the real repository satisfies every pinning rule" {
+    run node "$GATE" "$AAHP_ROOT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Workflow pinning OK"* ]]
+}
+
+# The finding this gate was written for, asserted directly on the two workflow
+# files rather than through the gate. This is deliberately NOT a restatement of
+# the test above: that one passes whenever the gate is satisfied, including if
+# the gate were later weakened. This one reads the workflow text itself, so it
+# still fails if the gate stops looking.
+@test "neither MANIFEST validation step can reach the registry" {
+    local ci="$AAHP_ROOT/.github/workflows/ci.yml"
+    local manifest="$AAHP_ROOT/.github/workflows/aahp-manifest.yml"
+
+    # The original defect: an unconstrained install of two undeclared packages.
+    run grep -c -- "--no-save" "$ci" "$manifest"
+    [ "$status" -eq 1 ]
+
+    # The fix, in both host jobs.
+    run grep -c -- "npx --no-install ajv-cli validate" "$ci"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+    run grep -c -- "npx --no-install ajv-cli validate" "$manifest"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+
+    # And the packages the two steps execute are declared here at exact versions.
+    run node "$AAHP_ROOT/tests/assert-pinning-gate-wired.mjs" "$AAHP_ROOT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pinning gate wiring OK"* ]]
+}
+
+@test "the baseline fixture is clean" {
+    write_good_fixture
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Workflow pinning OK"* ]]
+}
+
+# ─── Rule A: no project-level npm install in a workflow ─────────────────────
+
+@test "reintroducing the original unpinned install is red" {
+    write_good_fixture
+    cat >> "$(wf_dir)/ci.yml" <<'EOF'
+      - name: Validate MANIFEST schema
+        run: |
+          npm install --no-save ajv-cli ajv-formats
+          npx --no-install fx-tool validate -s schema.json -d data.json
+EOF
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"installs packages outside the committed lockfile"* ]]
+}
+
+@test "a bare npm install is red too, not only --no-save" {
+    write_good_fixture
+    cat >> "$(wf_dir)/ci.yml" <<'EOF'
+      - name: Sneak it in
+        run: npm install
+EOF
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"installs packages outside the committed lockfile"* ]]
+}
+
+@test "an install hidden behind a shell separator is still found" {
+    write_good_fixture
+    cat >> "$(wf_dir)/ci.yml" <<'EOF'
+      - name: Sneak it in
+        run: echo hello && npm i fx-tool ; echo done
+EOF
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"installs packages outside the committed lockfile"* ]]
+}
+
+@test "a global install is deliberately NOT a finding of this gate" {
+    # Scope, recorded in the gate header and on
+    # https://github.com/homeofe/AAHP/issues/68: `npm install -g` is a different
+    # risk class with an owner decision still open on it. This test exists so the
+    # exemption is a stated property with a test behind it rather than an
+    # accident of the regex, and so it fails loudly if the scope ever changes.
+    write_good_fixture
+    cat >> "$(wf_dir)/ci.yml" <<'EOF'
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+EOF
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+# ─── Rule B: npx must carry --no-install ────────────────────────────────────
+
+@test "dropping --no-install from npx is red" {
+    write_good_fixture
+    # The ONLY difference from the baseline: --no-install is gone.
+    cat > "$(wf_dir)/ci.yml" <<'EOF'
+name: fx
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Validate
+        run: npx fx-tool validate -s schema.json -d data.json
+EOF
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"without \`--no-install\`"* ]]
+}
+
+@test "npx -y is red, because -y is the opposite of a pin" {
+    write_good_fixture
+    cat >> "$(wf_dir)/ci.yml" <<'EOF'
+      - name: Fetch and run
+        run: npx -y fx-tool validate
+EOF
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"without \`--no-install\`"* ]]
+}
+
+# ─── Rule C: what npx executes must be declared here, at an exact version ───
+
+@test "executing a package this repository does not declare is red" {
+    write_pkg '"something-else": "1.2.3"'
+    write_lock
+    write_good_workflow
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"which package.json does not declare"* ]]
+}
+
+@test "a range instead of an exact version is red" {
+    write_pkg '"fx-tool": "^1.2.3"'
+    write_lock
+    write_good_workflow
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Declare an exact version"* ]]
+}
+
+# ─── Rule D: the lockfile pins every direct dependency by hash ──────────────
+
+@test "a lockfile entry without an integrity hash is red" {
+    write_pkg
+    write_lock '"version": "1.2.3", "resolved": "https://registry.npmjs.org/fx-tool/-/fx-tool-1.2.3.tgz"'
+    write_good_workflow
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no \`integrity\` hash in the lockfile"* ]]
+}
+
+@test "a declared dependency with no lockfile entry at all is red" {
+    write_pkg
+    cat > "$TEST_TMPDIR/package-lock.json" <<'EOF'
+{ "name": "fx", "lockfileVersion": 3, "packages": { "": { "name": "fx" } } }
+EOF
+    write_good_workflow
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"has no lockfile entry"* ]]
+}
+
+# ─── Exit 2: what the gate could not evaluate is never reported as clean ────
+
+@test "no workflow directory exits 2, not 0" {
+    write_pkg
+    write_lock
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no workflow directory"* ]]
+}
+
+@test "an empty workflow directory exits 2, not 0" {
+    write_pkg
+    write_lock
+    mkdir -p "$(wf_dir)"
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"contains no workflow files"* ]]
+}
+
+@test "unparseable YAML exits 2, not 0" {
+    write_pkg
+    write_lock
+    mkdir -p "$(wf_dir)"
+    printf 'jobs:\n  build:\n   steps:\n  - bad: [unclosed\n' > "$(wf_dir)/ci.yml"
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not valid YAML"* ]]
+}
+
+@test "a missing lockfile exits 2, not 0" {
+    write_pkg
+    write_good_workflow
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no package-lock.json"* ]]
+}
+
+# ─── The gate has to actually RUN ───────────────────────────────────────────
+
+@test "the gate is wired into the aggregate check chain" {
+    # A gate that exists but is never invoked protects nothing. The assertion
+    # lives in tests/assert-pinning-gate-wired.mjs - see the header there for why
+    # this is a file and not an inline `node -e`.
+    run node "$AAHP_ROOT/tests/assert-pinning-gate-wired.mjs" "$AAHP_ROOT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pinning gate wiring OK"* ]]
+}


### PR DESCRIPTION
Closes nothing on its own. Fixes the reproducible half of https://github.com/homeofe/AAHP/issues/68 and leaves the two owner decisions recorded on that issue untouched. The owner reviews and decides whether to close.

Independent reproduction this branch answers: https://github.com/homeofe/AAHP/issues/68#issuecomment-5380264212

## What was wrong

Two of the six required status checks on `main` downloaded and executed unpinned third-party code on every push and every pull request:

```yaml
run: |
  npm install --no-save ajv-cli ajv-formats
  npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
```

in `.github/workflows/ci.yml` (job `lint-and-validate`) and `.github/workflows/aahp-manifest.yml` (job `aahp-manifest`). `--no-save` guarantees the resolution is never written to `package-lock.json`, so the 27 packages that arrived were not reviewable, not diffable and not reproducible, and the next line executed them by design. One compromised release anywhere in that closure was arbitrary code execution inside the checks whose verdict certifies a change, in a repository whose published product is a set of CI gates other repositories install and trust.

## Root cause, and why the fix is not just a pin

The repository already knew how to do this correctly. `assets/governance/aahp-govern.yml`, the workflow template this package ships to consumers, has always used `npm ci --ignore-scripts` followed by `npx --no-install`, and `.github/workflows/aahp-verify.yml` pins its actions to full commit SHAs. Both are files strangers read. The workflows that only ever ran here did not follow the same rule, because nothing made them.

So the defect was not a forgotten pin. It was that pinning here was a hand-applied convention, and a convention has no failure mode: it simply stops being applied, silently, the first time someone rewrites a file. This branch turns it into a property of the repository, which does have one.

## What changed

Implementing commits: `aa7e085cf10cb5780bcfaa2757bbdb42c63ecfcc` (the fix and the gate) and `a67c320a3597174208677475276432330ff44f92` (the ReDoS fix CodeQL found on the first commit, described below).

1. `package.json` declares `ajv-cli` at `5.0.0` and `ajv-formats` at `3.0.1`, both exact. `package-lock.json` is regenerated and committed: the `packages` map holds 30 keys, of which the root `""` entry carries neither field and the other 29 each carry a `resolved` URL and an `integrity` hash. Rule D asserts this over the 4 direct dependencies, not over all 29. (Corrected during review.)
2. `.github/workflows/ci.yml` drops the install line entirely. `lint-and-validate` already ran `npm ci` earlier in the job, so the locked closure is present, and the validate step became `npx --no-install ajv-cli validate ...`.
3. `.github/workflows/aahp-manifest.yml` runs no other npm step, so it gained `npm ci --ignore-scripts` and the same `npx --no-install` invocation.
4. `scripts/check-workflow-pinning.mjs` is a new gate, wired into the aggregate `npm run check` chain that the required `lint-and-validate` job already executes. It adds no new required status context and needs no branch-protection change. It asserts four properties over every workflow in `.github/workflows` and every template in `assets/governance`:
   - no project-level `npm install`, `npm i` or `npm add`; the reproducible form is `npm ci`
   - every `npx` carries `--no-install`
   - every package a workflow executes is declared here at an exact version
   - every direct dependency is locked with both `resolved` and `integrity`

   Exit codes: `0` only when every scanned file was read and every rule held, `1` on a finding, `2` when it cannot evaluate (no YAML parser, no workflow directory, no workflow files, unparseable workflow, unreadable `package.json` or `package-lock.json`). Never `0` in those cases, so "I could not look" cannot read as "I looked and it was fine".
5. `CLAUDE.md` and `README.md` stopped teaching the unpinned form. The README block is the one strangers copy, and it taught `npx ajv validate ...` with no lockfile and no `--no-install`.
6. `tests/workflow-pinning.bats` (19 tests) and `tests/assert-pinning-gate-wired.mjs`.

`--no-install` is the load-bearing half and the reason this is not cosmetic. Without it, `npx` falls back to fetching from the registry whenever the local resolution misses, and the pin upstream buys nothing.

## Test evidence

Only the one test file covering this change was run locally. The full suite is deliberately not run on this machine; hosted Linux CI is the authoritative verdict for the rest, and it has now given it (see the CI section below).

```
$ bats tests/workflow-pinning.bats
1..18
ok 1 the real repository satisfies every pinning rule
ok 2 neither MANIFEST validation step can reach the registry
ok 3 the baseline fixture is clean
ok 4 reintroducing the original unpinned install is red
ok 5 a bare npm install is red too, not only --no-save
ok 6 an install hidden behind a shell separator is still found
ok 7 a global install is deliberately NOT a finding of this gate
ok 8 dropping --no-install from npx is red
ok 9 npx -y is red, because -y is the opposite of a pin
ok 10 executing a package this repository does not declare is red
ok 11 a range instead of an exact version is red
ok 12 a lockfile entry without an integrity hash is red
ok 13 a declared dependency with no lockfile entry at all is red
ok 14 no workflow directory exits 2, not 0
ok 15 an empty workflow directory exits 2, not 0
ok 16 unparseable YAML exits 2, not 0
ok 17 a missing lockfile exits 2, not 0
ok 18 the gate is wired into the aggregate check chain
EXIT=0
```

That is the first commit. The nineteenth test arrived with the ReDoS fix and is shown in that section.

Every rule is asserted in both directions: it holds on the real repository, and each separate way of breaking it turns the gate red at the exact documented exit code. Exit `1` and exit `2` are compared with `-eq`, never as "not zero", because they are different answers.

## Mutation proof

The mutation restores the exact defective step this branch removed, in `.github/workflows/ci.yml`. All four outcomes are verbatim below, and the mutation is proved to have landed before anything was run.

Pre-state:

```
===== STEP 1: PRE-STATE =====
0
grep-unpinned-exit=1
1
grep-fixed-exit=0
Workflow pinning OK: 8 workflow file(s), 2 pinned npx invocation(s), 4 direct dependencies locked by hash.
GATE_EXIT=0
```

Mutation applied, then proved present by re-reading the file from disk and grepping both for the mutated form and for the absence of the original (sequenced with `;`, never `&&`, so no failed step can lend its exit code to the next):

```
===== STEP 2: APPLY MUTATION =====
FIXED -> DEFECTIVE landed in .github/workflows/ci.yml; unpinned-install marker count = 1
MUTATE_EXIT=0
===== STEP 3: PROVE THE MUTATION LANDED (independent re-read) =====
1
grep-unpinned-exit=0
0
grep-fixed-exit=1

      - name: Validate MANIFEST.json against schema
        run: |
          npm install --no-save ajv-cli ajv-formats
          npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
```

RED, gate:

```
===== STEP 4: GATE ON THE MUTATED TREE =====

  Workflow pinning failed (2 finding(s)).

  - .github/workflows/ci.yml:lint-and-validate:Validate MANIFEST.json against schema
      npm install --no-save ajv-cli ajv-formats
      installs packages outside the committed lockfile. Use `npm ci`, which installs exactly the locked closure. `--no-save` in particular guarantees the resolution is never recorded anywhere.
  - .github/workflows/ci.yml:lint-and-validate:Validate MANIFEST.json against schema
      npx ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
      runs npx without `--no-install`, so npx falls back to fetching from the registry whenever the local resolution misses. Any pin upstream of this line buys nothing while this line can reach the network.

GATE_EXIT=1
```

RED, tests:

```
$ bats --filter "pinning rule|reach the registry" tests/workflow-pinning.bats
1..2
not ok 1 the real repository satisfies every pinning rule
# (in test file tests/workflow-pinning.bats, line 80)
#   `[ "$status" -eq 0 ]' failed
not ok 2 neither MANIFEST validation step can reach the registry
# (in test file tests/workflow-pinning.bats, line 95)
#   `[ "$status" -eq 1 ]' failed
BATS_EXIT=1
```

Restored, and the restore proved by the same independent re-read:

```
===== STEP 6: RESTORE =====
DEFECTIVE -> FIXED landed in .github/workflows/ci.yml; unpinned-install marker count = 0
RESTORE_EXIT=0
===== STEP 7: PROVE THE RESTORE LANDED (independent re-read) =====
0
grep-unpinned-exit=1
1
grep-fixed-exit=0
 .github/workflows/ci.yml | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
===== STEP 8: GATE ON THE RESTORED TREE =====
Workflow pinning OK: 8 workflow file(s), 2 pinned npx invocation(s), 4 direct dependencies locked by hash.
GATE_EXIT=0
```

GREEN, tests:

```
$ bats --filter "pinning rule|reach the registry" tests/workflow-pinning.bats
1..2
ok 1 the real repository satisfies every pinning rule
ok 2 neither MANIFEST validation step can reach the registry
BATS_EXIT=0
```

The exact lines a reviewer deletes to redden each test: `tests/workflow-pinning.bats:80` (`[ "$status" -eq 0 ]`, the gate verdict on this repository) and `tests/workflow-pinning.bats:95` (`[ "$status" -eq 1 ]`, the grep proving no `--no-save` install survives in either workflow). The second test is not a restatement of the first. It reads the workflow text directly rather than through the gate, so it still fails if the gate is later weakened, and it is the one that catches the validation step being deleted outright, which the gate alone would report as clean because a workflow with no `npx` line has nothing left to be unpinned.

## A defect CI found on this branch, and the fix for it

The first commit turned the `CodeQL` check red with two high-severity `js/redos` alerts, both against a regex this branch introduced:

```
scripts/check-workflow-pinning.mjs   js/redos  high
tests/assert-pinning-gate-wired.mjs  js/redos  high
"This part of the regular expression may cause exponential backtracking on strings
 starting with '9.9.9+' and containing many repetitions of '--'."
```

The alert is correct. The first form was

```js
/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/
```

and the repeated group starts with a character class that also contains `-`, so a run like `-a-a-a` can be partitioned exponentially many ways. The input is a `package.json` version specifier, which is attacker-supplied on a fork pull request, and the gate runs inside the required `lint-and-validate` job. Adding a supply-chain gate that itself hangs the required check would have been a poor trade.

Replaced with a form that allows at most one prerelease run and at most one build run, the second introduced by `+`, which the prerelease class excludes, so there is exactly one way to match:

```js
/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.]+)?$/
```

Measured on the exact input shape CodeQL named, old form against new:

```
reps=14 len=35  OLD 42.7 ms       NEW 0.088 ms
reps=18 len=43  OLD 214.6 ms      NEW 0.090 ms
reps=22 len=51  OLD 11800.2 ms    NEW 0.004 ms
```

Eleven point eight seconds on a 51-character string. Behaviour is unchanged **on the 19 specifiers tested**: 8 exact versions still accepted (including `1.2.3-beta.1`, `1.2.3+build.5` and `1.2.3-beta.1+build.5`) and 11 non-exact specifiers still rejected (`^5.0.0`, `~1.2.3`, `>=1.0.0`, `1.x`, `latest`, `*`, `1.2`, a `file:` path, a git URL, an `npm:` alias, an `||` range). **Corrected during review: it is not unchanged in general.** The new build class is `[0-9A-Za-z.]`, which excludes `-`, so SemVer-legal build metadata containing a hyphen is now rejected as a range. Re-derived here against the SemVer 2.0.0 reference regex as the oracle for "SemVer-legal", rather than taken from the earlier note. The narrowing is a SHAPE, not a list of five: every SemVer-legal version whose build metadata contains a hyphen flipped from accepted to rejected. Measured, old form against new - `1.0.0+21AF26D3----117B344092BD` (the SemVer spec's own example), `1.2.3+build-5`, `1.2.3-alpha+a-b`, `1.2.3-x+y-z`, `1.2.3-alpha-1+build-1`, `1.2.3+a-` and `0.0.4+-` all flipped, and so does anything else of that shape. One correction to the five originally named here: `1.2.3+a+b` also flipped, but it is NOT SemVer-legal, because SemVer permits only one `+`, so rejecting it is the regex getting stricter in the right direction, not a narrowing. Four of the five named were legal, not five.

What the narrowing costs, measured on a fixture rather than reasoned about. A hyphenated build pin:

```
$ node scripts/check-workflow-pinning.mjs <fixture declaring fx-tool at 1.2.3+build-5>

  Workflow pinning failed (1 finding(s)).

  - .github/workflows/ci.yml:build:Validate
      npx --no-install fx-tool
      executes "fx-tool", declared as "1.2.3+build-5". A range resolves through the lockfile but is not visible in the diff, which is where a supply-chain change has to be reviewable. Declare an exact version.

GATE_EXIT=1
```

and the same fixture with the hyphen replaced by a dot, as the positive control:

```
$ node scripts/check-workflow-pinning.mjs <fixture declaring fx-tool at 1.2.3+build.5>
Workflow pinning OK: 1 workflow file(s), 1 pinned npx invocation(s), 1 direct dependencies locked by hash.
    .github/workflows/ci.yml
GATE_EXIT=0
```

So the gate calls a legal exact pin a range and tells its author to declare an exact version, which is what they did. Neither the 19-specifier sample nor the nineteenth test can detect this, because none of them carries a hyphen in the build part.

**Corrected on this branch, in `4513e9a`.** The regex is deliberately UNCHANGED and the claims moved to meet it. `CHANGELOG.md` - which is inside `package.json` `files`, so it reaches npm and becomes the Release body - said "What counts as an exact version is unchanged" and now names the build class, the flipped shape and the five examples. The comment at `tests/workflow-pinning.bats:236` said the rewrite "must not have narrowed what counts as an exact version" and now says it did, and that this test's own `+build.5` fixture is green under both forms and therefore cannot see it. The narrowing is left in place because it runs fail-closed - nothing unpinned became acceptable, a legal pin became unacceptable - and is unreachable for the two packages the gate governs, `ajv-cli` 5.0.0 and `ajv-formats` 3.0.1, neither of which carries build metadata. If it is ever hit, put the hyphen back in the build class; it stays linear either way, since `+` cannot appear in it. Re-run after the correction:

```
$ bats --filter "prerelease|range instead|does not declare|pinning rule|reach the registry" tests/workflow-pinning.bats
1..5
ok 1 the real repository satisfies every pinning rule
ok 2 neither MANIFEST validation step can reach the registry
ok 3 executing a package this repository does not declare is red
ok 4 a range instead of an exact version is red
ok 5 an exact version carrying a prerelease and build suffix is accepted
BATS_EXIT=0
```

## Hosted Linux CI on the first commit

Every required status check passed on the first commit, and the full suite ran there rather than on a developer machine:

```
lint-and-validate     pass  1m39s      aahp-verify         pass  11s
Runtime matrix (22)   pass  1m44s      aahp-lint           pass  6s
Runtime matrix (24)   pass  1m31s      aahp-manifest       pass  11s
aahp-archive          pass  4s         aahp-pii-allowlist  pass  8s
CodeQL                fail  4s         (the js/redos alerts above, fixed in the second commit)
```

From the `lint-and-validate` log, the two things this branch changed, running for real:

```
Run npx --no-install ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
.ai/handoff/MANIFEST.json valid
Workflow pinning OK: 8 workflow file(s), 2 pinned npx invocation(s), 4 direct dependencies locked by hash.
1..423
```

`aahp-manifest`, the other affected required check, passed in 11 seconds with the new `npm ci --ignore-scripts` step.

And the fail-open tests really do run now. From the `Runtime matrix (24)` log, the three that used to print `# skip ajv-cli not installed` in that job:

```
ok 233 config example validates against the config schema
ok 234 config schema rejects malformed impact entries and unsafe path shapes
ok 238 init --gates config validates against aahp-config.schema.json
```

## Hosted Linux CI on the second commit

Of the twelve check runs, ten succeeded and two are skipped (`Publish to npm`, `Create GitHub Release`); CodeQL is among the ten. (Corrected during review: the original read "All twelve checks green".) The suite is 424 tests, and the nineteenth pinning test is among them:

```
1..424
ok 417 an exact version carrying a prerelease and build suffix is accepted
```

```
CodeQL              pass  2s          lint-and-validate   pass  1m59s
Runtime matrix (22) pass  1m55s       Runtime matrix (24) pass  1m44s
aahp-verify         pass  7s          aahp-lint           pass  5s
aahp-manifest       pass  14s         aahp-archive        pass  7s
aahp-pii-allowlist  pass  4s          Analyze (js/ts)     pass  51s
```

## Verification evidence

Trimmed for length, and flagged during review: the real run also prints the five pin lines `check:runtime-support` emits and the eight scanned-file lines `check:workflow-pinning` emits, so this block is not verbatim.

```
$ npm run check
Changelog presence OK: CHANGELOG.md contains an entry for 3.10.0.
Changelog format OK: 18 release(s), Keep a Changelog + SemVer, top=[3.10.0] matches package.json.
Version sync OK: package.json v3.10.0 matches all 1 configured version site(s).
Capability claims: none configured; nothing to check.
Forbidden patterns OK: 1 rule(s), no matches.
Schema-doc sync OK: 2 group(s) consistent.
Doc links OK: 17 internal file link(s) resolve.
Runtime support OK: engines.node >=22 (supported floor 22), matrix exercises 22 and 24.
Workflow pinning OK: 8 workflow file(s), 2 pinned npx invocation(s), 4 direct dependencies locked by hash.
Handoff generator OK: no LOG generation configured; NEXT_ACTIONS current-version matches package.json.
CHECK_EXIT=0
```

```
$ aahp doctor .
Conformance OK: 7 gate(s), no failures.
```

The runtime path both jobs now take was executed end to end on both npm majors CI uses, because `npx --no-install <package-name>` has to resolve a package whose only bin is named `ajv`:

```
$ rm -rf node_modules ; npm ci --ignore-scripts ; echo "npm ci exit=$?"
npm ci exit=0
$ npx --no-install ajv-cli validate --spec=draft2020 -c ajv-formats -s schema/aahp-manifest.schema.json -d .ai/handoff/MANIFEST.json
.ai/handoff/MANIFEST.json valid
exit=0
```

npm 10.9.9 (the Node 22 line, which `lint-and-validate` and `aahp-manifest` pin) and npm 11.12.1 (the Node 24 line the publish job pins) both resolve it and both print `valid`. `npx --no-install bats --version` also still works after `--ignore-scripts`, so nothing in the closure needed a lifecycle hook.

## The original finding no longer reproduces

The issue's own reproduction commands, re-run on this branch:

```
$ grep -rnE 'npm i(nstall)? .*--no-save|npm install -g' .github/workflows/
.github/workflows/ci.yml:139:        run: npm install -g npm@latest
grep exit=0

$ grep -rnE 'npm ci' .github/workflows/            # positive control
.github/workflows/aahp-manifest.yml:30:        run: npm ci --ignore-scripts
.github/workflows/ci.yml:36:        run: npm ci
.github/workflows/ci.yml:106:        run: npm ci
.github/workflows/ci.yml:136:      - run: npm ci
exit=0

$ grep -c 'ajv' package.json package-lock.json
package.json:2
package-lock.json:14
```

Before this branch, the first command returned three hits, two of them the `--no-save` installs, and the third returned `package.json:0` / `package-lock.json:0`. Both `--no-save` installs are gone and both packages are now declared and locked. The one remaining hit is `npm install -g npm@latest`, which is deliberately untouched and is the owner decision below.

## Deliberately not fixed here

Both are owner decisions recorded on https://github.com/homeofe/AAHP/issues/68, so this branch does not take them.

1. **`npm install -g npm@latest` in the publish job.** It is the only unpinned install inside the job holding `id-token: write`, immediately before `npm publish --provenance`, so on impact it is the most severe of the three. Its likelihood is much lower, because the supplier is the package manager published by the registry operator, and the two should not be described as one risk. The open question is whether the step should be DELETED rather than pinned: its comment asserts that OIDC trusted publishing needs npm >= 12, while the Node 24 line pinned in that same job already ships npm 11.12.1, and that assertion is unverified. Pinning it to a version chosen on an unverified premise would be worse than leaving it visible. The pinning gate names this exclusion in its own header rather than hiding it in an exemption list, and `tests/workflow-pinning.bats` has a test asserting the exemption, so it is a stated property that fails loudly if the scope changes rather than an accident of a regex.
2. **A dependency-scanning workflow, and whether it becomes a seventh required context.** Not added. Adding a required context blocks every pull request until the check reports at least once. Related and worth folding into that decision: `.github/dependabot.yml` has no `github-actions` ecosystem entry, so the floating action tags in six of the seven workflows are untracked as well.

## Things a reviewer should know

- **The lockfile's root `engines` moved from `>=18` to `>=22`.** That is `npm install` correcting a stale value against the `package.json` that already said `>=22`. It is a side effect of regenerating the lockfile, not a decision taken here.
- **`npm audit` now reports GHSA-8gh8-hqwg-xf34** (prototype pollution in `fast-json-patch` below 3.1.1). `ajv-cli` 5.0.0 requires `fast-json-patch ^2.0.0`, so it resolves to 2.2.1 and the advisory cannot be cleared without an `overrides` entry crossing a major version of a transitive dependency. This is not new exposure. The identical closure was already downloaded and executed on every CI run; declaring the packages is what made it visible to `npm audit` and to Dependabot at all. Left for the owner rather than force-resolved here.
- **Three schema tests stop failing open.** Two in `tests/handoff-impact.bats` and one in `tests/init-gates.bats` skip when `ajv-cli` cannot be resolved. They ran only in the one job that happened to have installed it and printed `# skip ajv-cli not installed` everywhere else while the check still went green. Now confirmed running on CI, above.
- **The gate is not in `bin/aahp.js` CHECK_GATES**, so it does not run against consumer projects via `aahp check`. Turning it on there would go red on the first run in most consumer repositories, which is a fleet-wide breaking change and a separate decision. It is wired into `npm run check` instead, the same position `check:runtime-support` occupies.
- **Rule C is asked only of workflows that run here**, not of the shipped templates in `assets/governance`, because a template runs against a consumer's `package.json` and this one is not the file that declares its `npx` target.


