### PR TITLE
docs(doctor): name the content check the handoff-set gate does not run

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,9 +11,9 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:e1720b4b08e47ded8b03ff229f10f0f9416190fa2b902c2491876bfddc18dd52",
-      "updated": "2026-08-22T22:37:52Z",
-      "lines": 160,
+      "checksum": "sha256:8b1cadab8156bc712469082d07caea6a7d0e1041b2ebfd3eb1f82dba2bc980a8",
+      "updated": "2026-08-22T22:39:02Z",
+      "lines": 167,
       "summary": "`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by"
     },
     "NEXT_ACTIONS.md": {
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 5423,
-    "full_read": 15493
+    "manifest_plus_core": 5544,
+    "full_read": 15614
   },
   "next_task_id": 18,
   "tasks": {

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,10 +11,10 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:d35aa54e0d175c52e6d90eb32cb660328cfc7c5b2d48ae7093ad06585e2097a1",
-      "updated": "2026-08-22T21:32:06Z",
-      "lines": 145,
-      "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
+      "checksum": "sha256:e1720b4b08e47ded8b03ff229f10f0f9416190fa2b902c2491876bfddc18dd52",
+      "updated": "2026-08-22T22:37:52Z",
+      "lines": 160,
+      "summary": "`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:efdc6ef8664faf9ce5120fa797b702d2353bd4c3205c62e5ba651a465326103d",
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4922,
-    "full_read": 14992
+    "manifest_plus_core": 5423,
+    "full_read": 15493
   },
   "next_task_id": 18,
   "tasks": {

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -72,16 +72,23 @@ behaviour changes: whether the `workflow_dispatch` operand should exist at all i
 owner's decision and is recorded as open, with its options, in ADR-019.
 `aahp doctor` also stops letting a green `handoff-set` line read as an integrity
 verdict. That gate compares the file SET and the INDEX and hashes nothing, which is
-the documented split: ADR-011 gives checksum integrity to `aahp verify` Layer 1,
-which compares it directly and also runs `aahp lint`, which compares it too. Its pass reason said only "N indexed files
-present, no strays", so a reader who had not read the ADR could take a green line for
-an integrity verdict. It now adds "(content not compared; aahp verify Layer 1 owns
-checksum integrity)", the same honest-summary treatment `scripts/lint-handoff.sh`
-received in 3.8.x. No gate changed behaviour, no exit code moved, and the `--json`
-record carries gate statuses and no reasons, so it is unchanged. README now names the
-one configuration where the split has consequences for an adopter: `verify-workflow`
-reporting `skip` while the handoff gates are evaluated means no automated gate in
-that repository compares a handoff checksum.
+the documented split: ADR-011 makes `aahp verify` the owner of handoff drift, and
+Layer 1 hashes each indexed file itself. Layer 1 also runs `aahp lint`, which
+compares them again, but only under a Python interpreter and exiting 0 when there is
+none, so lint is not a substitute for the gate. The pass reason said only "N indexed
+files present, no strays", so a reader who had not read the ADR could take a green
+line for an integrity verdict. It now adds "(content not compared; aahp verify
+Layer 1 owns checksum integrity)", the same honest-summary treatment
+`scripts/lint-handoff.sh` received in 3.9.0 (the CHANGELOG records it under 3.8.3,
+a version number that was never published). No gate changed behaviour and no exit
+code moved. The LIMIT is now stated in the source comment, in the README and in the
+CHANGELOG rather than only in the pull request: only the default human-readable
+`doctor` output carries the new reason, while `--json`, `--quiet` and `--governance`
+do not, and those three are the invocations consumers wire into CI and hooks, so the
+`schemaVersion: 1` record a dashboard ingests says exactly what it said before.
+README also names the one configuration where the split has consequences for an
+adopter: `verify-workflow` reporting `skip` while the handoff gates are evaluated
+means no automated gate in that repository compares a handoff checksum.
 <!-- /SECTION: summary -->
 
 ---

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -14,7 +14,7 @@ the changed entries, which no driver can do.
 
 # AAHP: Current State of the Nation
 
-> Last updated: 2026-08-22 by claude (verify-workflow gate: can the workflow that runs the gate skip it?)
+> Last updated: 2026-08-22 by claude (doctor says what it did not compare; verify-workflow gate)
 > Commit: (review branch, pending commit)
 >
 > **Rule:** This file is rewritten (not appended) at the end of every session.
@@ -70,6 +70,18 @@ written once and both jobs must use exactly it; every additional top-level `||`
 operand on the publish condition must appear in a literal recorded list. No workflow
 behaviour changes: whether the `workflow_dispatch` operand should exist at all is the
 owner's decision and is recorded as open, with its options, in ADR-019.
+`aahp doctor` also stops letting a green `handoff-set` line read as an integrity
+verdict. That gate compares the file SET and the INDEX and hashes nothing, which is
+the documented split: ADR-011 gives checksum integrity to `aahp verify` Layer 1,
+which compares it directly and also runs `aahp lint`, which compares it too. Its pass reason said only "N indexed files
+present, no strays", so a reader who had not read the ADR could take a green line for
+an integrity verdict. It now adds "(content not compared; aahp verify Layer 1 owns
+checksum integrity)", the same honest-summary treatment `scripts/lint-handoff.sh`
+received in 3.8.x. No gate changed behaviour, no exit code moved, and the `--json`
+record carries gate statuses and no reasons, so it is unchanged. README now names the
+one configuration where the split has consequences for an adopter: `verify-workflow`
+reporting `skip` while the handoff gates are evaluated means no automated gate in
+that repository compares a handoff checksum.
 <!-- /SECTION: summary -->
 
 ---
@@ -90,6 +102,7 @@ owner's decision and is recorded as open, with its options, in ADR-019.
 | `tests/runtime-support.bats` | FOCUSED PASS | 16/16; the relation holds on this repo and each of nine mutations turns it red, including the emptied-matrix trap |
 | shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |
 | hosted Linux suite | REPLACEMENT REQUIRED | `c332a23` passed 361/362; the CI mode fixture let `git add` restore mode 100644 on Linux, so it now reasserts 100755 before its content-plus-mode commit |
+| `tests/doctor.bats` (3 new tests) | FOCUSED PASS | the three content-drift tests pass under Git Bash; two were mutated red and restored green. The other 16 tests in the file were not run on Windows; Linux CI is authoritative |
 | full Bats suite | CI | deliberately not run on Windows; Linux CI is authoritative |
 | `tests/runtime-support.bats` (release authorization) | FOCUSED PASS | 8/8 added; the untouched repository shape is green, six one-line mutations of the REAL `ci.yml` each turn it red at exit 1 (including a publish job with no `if:` at all), and a reformat of the same expression stays green |
 <!-- /SECTION: build_health -->
@@ -106,6 +119,8 @@ owner's decision and is recorded as open, with its options, in ADR-019.
 | Required workflow | `.github/workflows/aahp-verify.yml` | Changed | no actor bypass; explicit base; read-only token; immutable action pins; evaluator-path trust boundary documented |
 | Config schema/example | `schema/aahp-config.schema.json`, `aahp.config.example.json` | Changed | additive `handoffImpact` contract |
 | CLI | `bin/aahp.js` | Changed | verify help documents `--base SHA` |
+| Conformance gate | `bin/aahp.js` (`gateHandoffSet`) | Changed | pass reason names the content check it does not run, and a header comment states the ADR-011 boundary; behaviour, gate statuses and the JSON record are unchanged |
+| Scaffolded governance workflow | `assets/governance/aahp-govern.yml` | Changed | header now states that it runs no handoff-integrity gate and that a repository keeping `.ai/handoff/` needs `aahp-verify.yml` beside it; comment only |
 | Specification | `README.md` | Changed | Section 2.8 and ADR-018 define the contract |
 | Rollout | `scripts/ROLLOUT.md` | Changed | consumer propagation and mutation checks documented |
 | Manifest generator | `scripts/aahp-manifest.sh` | Changed | `project` resolves from repository identity (recorded name, then git remote), not from the directory it runs in |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,28 @@ independently of the npm version).
   global pin list populated.
 
 ### Changed
+- `aahp doctor`'s `handoff-set` gate now names the check it did not run. Its pass
+  reason reads `N indexed files present, no strays (content not compared; aahp
+  verify Layer 1 owns checksum integrity)`. The gate's behaviour is unchanged, and
+  deliberately so: it compares the file SET and the INDEX, while comparing a
+  recorded checksum against the bytes on disk belongs to `aahp verify` Layer 1 and
+  to `aahp lint`, by ADR-011. What was missing is the honest-summary treatment
+  `scripts/lint-handoff.sh` received in 3.8.x, where a clean run that could not
+  establish integrity stopped printing "All checks passed". Without it, a green
+  `handoff-set` line reads as an integrity verdict to anyone who has not read the
+  ADR. The `--json` record carries gate statuses only, no reasons, so it is
+  byte-for-byte what it was and every ingesting dashboard is unaffected.
+- README now states the one configuration in which that split has consequences for
+  an adopter: when `verify-workflow` reports `skip`, meaning no workflow in the
+  repository runs the AAHP verify gate, and the handoff gates are still evaluated,
+  then no automated gate in that repository compares a handoff checksum, and a
+  green conformance record is not an integrity signal. Repositories using the shipped
+  `aahp-verify.yml` are unaffected: it runs `aahp verify --level ci` before
+  `aahp doctor` in the same job, so a drift fails the job before `doctor` runs.
+- `assets/governance/aahp-govern.yml`, the workflow `aahp init --gates` scaffolds
+  into consumers, now says in its own header that it runs no handoff-integrity gate
+  and that a repository which also keeps `.ai/handoff/` needs `aahp-verify.yml`
+  beside it. Comment only; the workflow itself is unchanged.
 - `engines.node` is now `>=22`, was `>=18`. Node 18 reached end of life on 2025-04-30
   and Node 20 on 2026-04-30, so the package publicly claimed support for a runtime it
   could not have security-patched, and every repository in the estate inherited that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,13 +64,19 @@ independently of the npm version).
   reason reads `N indexed files present, no strays (content not compared; aahp
   verify Layer 1 owns checksum integrity)`. The gate's behaviour is unchanged, and
   deliberately so: it compares the file SET and the INDEX, while comparing a
-  recorded checksum against the bytes on disk belongs to `aahp verify` Layer 1 and
-  to `aahp lint`, by ADR-011. What was missing is the honest-summary treatment
-  `scripts/lint-handoff.sh` received in 3.8.x, where a clean run that could not
+  recorded checksum against the bytes on disk belongs to `aahp verify` Layer 1,
+  which ADR-011 makes the owner of handoff drift. What was missing is the
+  honest-summary treatment `scripts/lint-handoff.sh` received in 3.9.0 (the
+  `[3.8.3]` entry below describes it; 3.8.2 and 3.8.3 were never published, and
+  3.9.0 is the first release that carries it), where a clean run that could not
   establish integrity stopped printing "All checks passed". Without it, a green
   `handoff-set` line reads as an integrity verdict to anyone who has not read the
-  ADR. The `--json` record carries gate statuses only, no reasons, so it is
-  byte-for-byte what it was and every ingesting dashboard is unaffected.
+  ADR. The new wording reaches ONE surface, and that limit is deliberate: the
+  `--json` record carries gate statuses only and no reasons, `--quiet` prints
+  nothing for a passing gate, and `--governance` skips the gate without
+  evaluating it. A repository that ingests the `schemaVersion: 1` record is
+  therefore told exactly what it was told before, which is the compatibility
+  choice this entry is making rather than an omission.
 - README now states the one configuration in which that split has consequences for
   an adopter: when `verify-workflow` reports `skip`, meaning no workflow in the
   repository runs the AAHP verify gate, and the handoff gates are still evaluated,
@@ -78,10 +84,17 @@ independently of the npm version).
   green conformance record is not an integrity signal. Repositories using the shipped
   `aahp-verify.yml` are unaffected: it runs `aahp verify --level ci` before
   `aahp doctor` in the same job, so a drift fails the job before `doctor` runs.
+  The README no longer offers `aahp lint` as an equivalent remedy: lint's
+  checksum comparison runs only under a Python interpreter and exits 0 when
+  there is none, so it can pass silently on a drifted tree where Layer 1 fails.
 - `assets/governance/aahp-govern.yml`, the workflow `aahp init --gates` scaffolds
-  into consumers, now says in its own header that it runs no handoff-integrity gate
-  and that a repository which also keeps `.ai/handoff/` needs `aahp-verify.yml`
-  beside it. Comment only; the workflow itself is unchanged.
+  into consumers, now says in its own header that it runs no handoff-integrity gate,
+  that neither of its own steps stands in for one (`aahp check` has no file-set or
+  index gate, and its `aahp doctor --governance` step skips the handoff gates
+  without evaluating them), that `aahp lint` cannot stand in for one in a workflow
+  that sets up Node and not Python, and that a repository which also keeps
+  `.ai/handoff/` needs `aahp-verify.yml` beside it. Comment only; the workflow
+  itself is unchanged.
 - `engines.node` is now `>=22`, was `>=18`. Node 18 reached end of life on 2025-04-30
   and Node 20 on 2026-04-30, so the package publicly claimed support for a runtime it
   could not have security-patched, and every repository in the estate inherited that

--- a/README.md
+++ b/README.md
@@ -613,14 +613,30 @@ audit reads and on the resulting findings.
 compares `MANIFEST.json` against the schema, which rejects a MALFORMED checksum
 but says nothing about a well-formed one that no longer matches the bytes.
 Comparing recorded checksums against file content belongs to `aahp verify`
-Layer 1, and to `aahp lint`, which Layer 1 also runs (ADR-011). The
-`handoff-set` pass reason therefore names the boundary instead of leaving a green
-line to imply integrity:
+Layer 1, which ADR-011 makes the owner of handoff drift. Layer 1 hashes each
+indexed file itself and additionally runs `aahp lint`, which compares them
+again. Do not substitute `aahp lint` for that gate: its comparison runs only
+under a Python interpreter, and with none on `PATH` it prints that MANIFEST
+integrity was NOT verified and still exits 0, so it reports nothing on a
+drifted tree. Layer 1 fails outright when no interpreter is available. The
+`handoff-set` pass reason therefore names the boundary instead of leaving a
+green line to imply integrity:
 
 ```text
-  PASS     handoff-set: 3 indexed files present, no strays (content not compared;
-           aahp verify Layer 1 owns checksum integrity)
+  PASS     handoff-set: 3 indexed files present, no strays (content not compared; aahp verify Layer 1 owns checksum integrity)
 ```
+
+That reason is emitted on one line, and only by the DEFAULT human-readable
+output. That is the limit of this wording, and it is deliberate:
+`aahp doctor --json` carries gate statuses and no reasons,
+`aahp doctor --quiet` prints nothing for a passing gate, and
+`aahp doctor --governance` marks the gate `skip` without evaluating it. Those
+three are the invocations wired into `.github/workflows/aahp-verify.yml`,
+`assets/governance/aahp-govern.yml` and `scripts/hooks/pre-push`, so a
+repository that treats the `schemaVersion: 1` record as its handoff-integrity
+signal reads exactly what it read before. Holding that record byte-identical is
+a compatibility choice for dashboards that already ingest it; changing it would
+be a `schemaVersion` decision.
 
 One configuration deserves an explicit warning. When `verify-workflow` reports
 `skip`, meaning no workflow in the repository runs the AAHP verify gate, and the
@@ -629,11 +645,11 @@ compares a handoff checksum. `aahp doctor` exits 0, `aahp check` exits 0, and a
 handoff file edited outside the protocol is invisible to both. The record is
 accurate about what it measured and it is not an integrity signal. Fix it by
 adopting `.github/workflows/aahp-verify.yml`, which runs `aahp verify --level ci`
-before `aahp doctor` in the same job, or by running `aahp verify` (or `aahp lint`,
-which compares the same checksums) some other way.
+before `aahp doctor` in the same job, or by running `aahp verify` some other
+way.
 
-In this repository, and in every consumer using the propagated workflow, that
-ordering is already in place: a checksum drift fails the job at the verify step
+In this repository, and in any repository whose `aahp-verify.yml` matches the
+shipped one, that ordering is already in place: a checksum drift fails the job at the verify step
 and the `doctor` step never runs, so a green record cannot mask the drift.
 
 **`aahp check`** is the pass/fail counterpart to that record. Where `doctor` emits a

--- a/README.md
+++ b/README.md
@@ -540,12 +540,12 @@ aahp doctor --governance # governance-only record; skip the 3 handoff gates (ali
 ```
 
 It checks seven gates: the handoff file set matches `AAHP_HANDOFF_FILES` (indexed
-files present, no strays); `MANIFEST.json` conforms to the schema; `GROUNDING.md`
-is present and `TRUST.md` carries a Provenance column; `@elvatis_com/aahp` is
-pinned to an exact version in `devDependencies` (`self` for this repo); the
-`CHANGELOG.md` matches the Keep a Changelog grammar; the version is in sync
-across configured sites; and the workflow that runs the AAHP gate cannot skip it
-(`verify-workflow`, below). The record:
+files present, no strays, file content not compared); `MANIFEST.json` conforms to
+the schema; `GROUNDING.md` is present and `TRUST.md` carries a Provenance column;
+`@elvatis_com/aahp` is pinned to an exact version in `devDependencies` (`self` for
+this repo); the `CHANGELOG.md` matches the Keep a Changelog grammar; the version
+is in sync across configured sites; and the workflow that runs the AAHP gate
+cannot skip it (`verify-workflow`, below). The record:
 
 ```json
 { "schemaVersion": 1, "repo": "homeofe/AAHP", "aahpVersion": "3.6.0",
@@ -605,6 +605,36 @@ real YAML would be the worst possible engine for a security gate, so
 `tests/assert-workflow-parser-parity.mjs` compares it against a real YAML parser on
 every workflow in this repository and every fixture, on exactly the fields the
 audit reads and on the resulting findings.
+
+#### What `doctor` does not check: handoff file content
+
+`doctor` never hashes a handoff file, and neither does `aahp check`. The
+`handoff-set` gate compares the file SET and the INDEX. `manifest-schema`
+compares `MANIFEST.json` against the schema, which rejects a MALFORMED checksum
+but says nothing about a well-formed one that no longer matches the bytes.
+Comparing recorded checksums against file content belongs to `aahp verify`
+Layer 1, and to `aahp lint`, which Layer 1 also runs (ADR-011). The
+`handoff-set` pass reason therefore names the boundary instead of leaving a green
+line to imply integrity:
+
+```text
+  PASS     handoff-set: 3 indexed files present, no strays (content not compared;
+           aahp verify Layer 1 owns checksum integrity)
+```
+
+One configuration deserves an explicit warning. When `verify-workflow` reports
+`skip`, meaning no workflow in the repository runs the AAHP verify gate, and the
+handoff gates are still evaluated, then no automated gate in that repository
+compares a handoff checksum. `aahp doctor` exits 0, `aahp check` exits 0, and a
+handoff file edited outside the protocol is invisible to both. The record is
+accurate about what it measured and it is not an integrity signal. Fix it by
+adopting `.github/workflows/aahp-verify.yml`, which runs `aahp verify --level ci`
+before `aahp doctor` in the same job, or by running `aahp verify` (or `aahp lint`,
+which compares the same checksums) some other way.
+
+In this repository, and in every consumer using the propagated workflow, that
+ordering is already in place: a checksum drift fails the job at the verify step
+and the `doctor` step never runs, so a green record cannot mask the drift.
 
 **`aahp check`** is the pass/fail counterpart to that record. Where `doctor` emits a
 conformance snapshot, `check` runs the config-driven governance gates as one aggregate

--- a/assets/governance/aahp-govern.yml
+++ b/assets/governance/aahp-govern.yml
@@ -6,6 +6,14 @@
 # so there are no vendored script paths to maintain. Verify-only: it never
 # mutates the repository, and it honors no skip or bypass environment variable.
 #
+# This workflow runs NO handoff-integrity gate. `aahp check` and `aahp doctor`
+# compare the handoff file set and the index; comparing a recorded checksum
+# against the bytes on disk belongs to `aahp verify` Layer 1 and to `aahp lint`,
+# by ADR-011. If this repository also keeps `.ai/handoff/`, add
+# `.github/workflows/aahp-verify.yml` beside this file and make it a required
+# status check. Without it no gate here compares a handoff checksum, and a green
+# conformance record is a statement about conformance, not integrity.
+#
 # Prerequisites in the consumer repo:
 #   - @elvatis_com/aahp pinned as an exact devDependency (npm i -D -E @elvatis_com/aahp)
 #   - a committed package-lock.json (npm ci needs it)

--- a/assets/governance/aahp-govern.yml
+++ b/assets/governance/aahp-govern.yml
@@ -6,13 +6,22 @@
 # so there are no vendored script paths to maintain. Verify-only: it never
 # mutates the repository, and it honors no skip or bypass environment variable.
 #
-# This workflow runs NO handoff-integrity gate. `aahp check` and `aahp doctor`
-# compare the handoff file set and the index; comparing a recorded checksum
-# against the bytes on disk belongs to `aahp verify` Layer 1 and to `aahp lint`,
-# by ADR-011. If this repository also keeps `.ai/handoff/`, add
+# This workflow runs NO handoff-integrity gate, and neither of its two steps
+# stands in for one. `aahp check` runs the config-driven governance gates only:
+# it has no file-set gate and no index gate. `aahp doctor --governance`, the
+# step below, marks handoff-set, manifest-schema and grounding as `skip`
+# WITHOUT evaluating them. Comparing a recorded checksum against the bytes on
+# disk is `aahp verify` Layer 1's job; ADR-011 assigns handoff drift to
+# `aahp verify`. If this repository also keeps `.ai/handoff/`, add
 # `.github/workflows/aahp-verify.yml` beside this file and make it a required
 # status check. Without it no gate here compares a handoff checksum, and a green
 # conformance record is a statement about conformance, not integrity.
+#
+# `aahp lint` is not a substitute either, least of all here: its checksum
+# comparison runs only under a Python interpreter, and this workflow sets up
+# Node and not Python. With no interpreter present lint reports that MANIFEST
+# integrity was NOT verified and still exits 0, so it would turn a drifted tree
+# green. `aahp verify` Layer 1 fails outright when it has no interpreter.
 #
 # Prerequisites in the consumer repo:
 #   - @elvatis_com/aahp pinned as an exact devDependency (npm i -D -E @elvatis_com/aahp)

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -559,6 +559,26 @@ function runGate(scriptName, targetPath) {
   return spawnSync(process.execPath, [join(PACKAGE_ROOT, 'scripts', scriptName), targetPath], { encoding: 'utf8' })
 }
 
+// ---------------------------------------------------------------------------
+// handoff-set gate - the file SET and the INDEX, never the file CONTENT.
+//
+// This gate hashes nothing. It answers three questions: is every indexed file
+// on disk, is every canonical file on disk also in files{}, and is anything
+// untracked lying next to them. Whether the bytes still match the recorded
+// checksum is `aahp verify` Layer 1's question, by ADR-011: Layer 1 compares
+// them itself and also runs scripts/lint-handoff.sh, which compares them again.
+// Neither `aahp doctor` nor `aahp check` compares content, so neither can
+// observe drift. The pass reason below says so out loud rather than leaving a
+// green line to imply otherwise, the same way scripts/lint-handoff.sh reports a
+// clean run whose MANIFEST integrity it could not verify.
+//
+// The one configuration where that matters to an adopter: when the
+// `verify-workflow` gate reports `skip` (no workflow in this repository runs
+// the AAHP verify gate) and the handoff gates are still evaluated, NO automated
+// gate in that repository compares a handoff checksum. The record is green and honest
+// about what it measured, and it is not a statement about handoff integrity.
+// Adopt .github/workflows/aahp-verify.yml, which runs `aahp verify --level ci`
+// before `aahp doctor` in the same job, or run `aahp verify` some other way.
 function gateHandoffSet(handoffDir) {
   const manifestPath = join(handoffDir, 'MANIFEST.json')
   if (!existsSync(manifestPath)) return { status: 'fail', reason: 'MANIFEST.json not found' }
@@ -587,7 +607,14 @@ function gateHandoffSet(handoffDir) {
   }
   const strays = entries.filter((f) => /\.(md|json)$/.test(f) && f !== 'MANIFEST.json' && !canonical.has(f))
   if (strays.length) return { status: 'fail', reason: `untracked stray handoff file(s): ${strays.join(', ')}` }
-  return { status: 'pass', reason: `${Object.keys(files).length} indexed files present, no strays` }
+  // Name what was NOT compared. A bare "no strays" reads as an integrity
+  // verdict to anyone who has not read ADR-011; this gate never hashed a byte.
+  return {
+    status: 'pass',
+    reason:
+      `${Object.keys(files).length} indexed files present, no strays` +
+      ' (content not compared; aahp verify Layer 1 owns checksum integrity)'
+  }
 }
 
 function gateManifestSchema(handoffDir) {

--- a/bin/aahp.js
+++ b/bin/aahp.js
@@ -565,12 +565,29 @@ function runGate(scriptName, targetPath) {
 // This gate hashes nothing. It answers three questions: is every indexed file
 // on disk, is every canonical file on disk also in files{}, and is anything
 // untracked lying next to them. Whether the bytes still match the recorded
-// checksum is `aahp verify` Layer 1's question, by ADR-011: Layer 1 compares
-// them itself and also runs scripts/lint-handoff.sh, which compares them again.
+// checksum is `aahp verify` Layer 1's question. ADR-011 assigns handoff drift
+// to `aahp verify`; the comparison itself lives in scripts/verify-handoff.sh,
+// which hashes each indexed file against its recorded checksum and additionally
+// runs scripts/lint-handoff.sh, which compares them again. lint is NOT a
+// substitute for Layer 1: its comparison runs only under a Python interpreter,
+// and with none on PATH lint reports that MANIFEST integrity was NOT verified
+// and still exits 0. Layer 1 fails outright when no interpreter is available.
 // Neither `aahp doctor` nor `aahp check` compares content, so neither can
 // observe drift. The pass reason below says so out loud rather than leaving a
 // green line to imply otherwise, the same way scripts/lint-handoff.sh reports a
 // clean run whose MANIFEST integrity it could not verify.
+//
+// LIMIT OF THIS WORDING, deliberate, and the thing to know before relying on
+// it: only the DEFAULT human-readable `aahp doctor` output carries the reason.
+// `--json` carries gate statuses and no reasons, `--quiet` prints nothing for a
+// passing gate, and `--governance` marks this gate `skip` without evaluating
+// it. Those three are the invocations wired into CI and hooks
+// (.github/workflows/aahp-verify.yml, assets/governance/aahp-govern.yml,
+// scripts/hooks/pre-push), so a repository that reads the schemaVersion 1
+// record as a handoff-integrity signal is told exactly what it was told before.
+// Holding that record byte-identical is a compatibility choice for dashboards
+// that already ingest it; changing it is a schemaVersion decision, not taken
+// here.
 //
 // The one configuration where that matters to an adopter: when the
 // `verify-workflow` gate reports `skip` (no workflow in this repository runs

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -263,3 +263,51 @@ EOF
       });
     '
 }
+
+# --- Handoff content drift: the boundary doctor does NOT cross (issue 72) -----
+#
+# `gateHandoffSet` compares the file SET and the INDEX and hashes nothing.
+# Comparing a recorded checksum against the bytes on disk is `aahp verify`
+# Layer 1's job, by ADR-011. These three tests hold that boundary from both
+# sides: doctor stays green AND says what it did not compare, and the drift the
+# other two rely on is proved to be real drift.
+
+# Conformant fixture, then STATUS.md content changed WITHOUT regenerating
+# MANIFEST.json. Byte length and line count are preserved on purpose, so the
+# content hash is the only thing that differs from the recorded entry and no
+# other gate has a second reason to notice.
+scaffold_drifted_handoff() {
+    scaffold_conformant
+    local h="$TEST_TMPDIR/.ai/handoff"
+    printf '# STATUS\n\nrecorded body aaaa\n' > "$h/STATUS.md"
+    create_manifest_json "$h"
+    printf '# STATUS\n\ndrifted body bbbbb\n' > "$h/STATUS.md"
+}
+
+@test "doctor: the handoff-set pass reason names the content check it did not run" {
+    scaffold_drifted_handoff
+    run node "$AAHP" doctor "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no strays (content not compared; aahp verify Layer 1 owns checksum integrity)"* ]]
+}
+
+@test "doctor --json: handoff-set stays pass on content drift (ADR-011 boundary, not scope creep)" {
+    scaffold_drifted_handoff
+    run node "$AAHP" doctor "$TEST_TMPDIR" --json
+    [ "$status" -eq 0 ]
+    echo "$output" | node -e '
+      let s = "";
+      process.stdin.on("data", (d) => (s += d)).on("end", () => {
+        const r = JSON.parse(s);
+        if (r.gates["handoff-set"] !== "pass") process.exit(2);
+        if (r.gates["manifest-schema"] !== "pass") process.exit(3);
+      });
+    '
+}
+
+@test "doctor drift fixture: aahp verify DOES see the drift (guard for the two tests above)" {
+    scaffold_drifted_handoff
+    run bash "$SCRIPTS_DIR/verify-handoff.sh" "$TEST_TMPDIR" --level precommit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Checksum mismatch: STATUS.md"* ]]
+}


### PR DESCRIPTION
Closes-after-owner-review: https://github.com/homeofe/AAHP/issues/72

## What this is

Issue 72 was filed as `bug` / `priority: medium`. An independent reproduction
(https://github.com/homeofe/AAHP/issues/72#issuecomment-5380309499) confirmed the
BEHAVIOUR and refuted the MECHANISM, and downgraded it to a documentation and clarity
item. This pull request implements that, and nothing more. **No gate changes
behaviour. No exit code moves. The `--json` conformance record is untouched.**

The issue is retitled and relabelled to `documentation` / `priority: low` to match the
evidence, with the original text preserved verbatim at the bottom of the issue.

## Pre-merge review repairs (commit `55e64e0`)

An independent pre-merge review
(https://github.com/homeofe/AAHP/pull/79#issuecomment-5381457473) found that the code
was right and several of the sentences shipping with it were not. This branch now
carries a second commit that repairs them. Seven repairs, each verified against the
code rather than against the review:

1. **A false statement was being scaffolded into consumer repositories.**
   `assets/governance/aahp-govern.yml` claimed that "`aahp check` and `aahp doctor`
   compare the handoff file set and the index". Neither half holds for that workflow.
   `aahp check`'s gate registry in `bin/aahp.js` is `changelog`, `changelog-format`,
   `version-sync`, `claims`, `forbidden-patterns`, `schema-doc-sync`, `doc-links` and
   `handoff`, where `handoff` is the dashboard generator check; there is no file-set
   gate and no index gate. Confirmed by running it: `aahp check .` on this repository
   reports those eight gate ids and no handoff-set line. And the workflow's own doctor
   step is `doctor --governance --json`, which marks `handoff-set`, `manifest-schema`
   and `grounding` as `skip` WITHOUT evaluating them. Confirmed by running it: the
   record returns `"handoff-set": "skip"`, exit 0. The header now states the true
   premise, and keeps the conclusion, which was already correct.

2. **`aahp lint` is no longer offered as an equivalent of `aahp verify` Layer 1.**
   README, the scaffolded workflow header and the gate's source comment all put lint
   beside Layer 1 unqualified, and README offered it as a remedy an adopter could use
   instead. Its checksum comparison runs only inside an embedded Python program in
   `scripts/lint-handoff.sh`. With no interpreter on `PATH` the comparison never runs,
   `INTEGRITY_UNVERIFIED` is set, and the summary still exits 0. Layer 1 has no such
   hole: `scripts/verify-handoff.sh` hashes each indexed file itself and fails outright
   when neither node nor python is available. The scaffolded governance workflow sets up
   Node and not Python, so an adopter following the old sentence could have wired in a
   control that silently does nothing. All three places now say lint is not a
   substitute, and why.

3. **A historical claim that was wrong in two published surfaces.** `CHANGELOG.md` and
   `.ai/handoff/STATUS.md` both said the honest-summary treatment
   `scripts/lint-handoff.sh` received was "in 3.8.x". Measured, not assumed. The commit
   that introduced `INTEGRITY_UNVERIFIED` and the "No violations found, but MANIFEST
   integrity was NOT verified here" summary is `038939b`. The earliest tag containing it
   is `v3.9.0`. `git show v3.8.1:scripts/lint-handoff.sh` contains that summary wording
   0 times and `INTEGRITY_UNVERIFIED` 0 times, with `All checks passed` present twice as
   the positive control; `v3.9.0` contains `INTEGRITY_UNVERIFIED` 3 times.
   `npm view @elvatis_com/aahp versions` lists `3.8.0` and `3.8.1` and then jumps to
   `3.9.0`: **3.8.2 and 3.8.3 were never published**, although this CHANGELOG records
   the change under `[3.8.3]`. Both places now say 3.9.0 and name the `[3.8.3]` entry,
   so a reader who pins a published 3.8.x is not told they have a behaviour they do not
   have.

4. **The ADR-011 citation is narrowed to what ADR-011 says.** ADR-011 assigns handoff
   drift to `aahp verify` and says nothing about `aahp lint` or about Layer 1 internals.
   The lint fact is true and is now attributed to the script that carries it rather than
   to the ADR.

5. **The limit of this change is now stated where the next reader meets it**, in the
   gate's source comment, in README and in CHANGELOG, rather than only in this body.
   See "Limits of this change" below.

6. **README no longer shows output `doctor` does not print.** The pass reason was
   presented wrapped over two lines inside a ` ```text ` fence. `bin/aahp.js` prints it
   on one line. The fence now matches a real run.

7. **A fleet claim nobody measured is gone.** "in every consumer using the propagated
   workflow" now reads "in any repository whose `aahp-verify.yml` matches the shipped
   one", which is the property that was actually checked.

**Interaction with another open pull request.**
https://github.com/homeofe/AAHP/pull/87 also edits
`assets/governance/aahp-govern.yml`, adding a `permissions:` block and a hardening note
below the prerequisites list; this pull request edits the header above that list, so the
two hunks do not overlap. Whichever merges second should still re-read the combined
header once rather than trust a clean automatic merge, because both are prose that ships
into consumer repositories.

The repair commit changes 21 lines in `bin/aahp.js` and **0 of them are non-comment
lines** (`git diff dc2ece7..HEAD -- bin/aahp.js`, filtered to added and removed lines,
then filtered to lines not beginning with `//`, returns 0). No executable line moved, so
the emitted reason string is byte-identical and the three tests are unaffected.

## Root cause addressed

Not a missing checksum comparison. `gateHandoffSet` is a set-and-index gate by design,
and the split is stated in two shipped ADRs: ADR-011 gives handoff drift to
`aahp verify` and the conformance record to `aahp doctor`; ADR-012 says the
`doctor` / `check` overlap is intentional.

The real root cause is a house pattern applied everywhere except one surface: **doctor's
output states nothing about what it did NOT verify.** This project already adopted the
opposite pattern for precisely this situation in 3.9.0, where `scripts/lint-handoff.sh`
stopped printing "All checks passed" for a run that could not establish integrity and
now prints, at `scripts/lint-handoff.sh:417-418`:

```
  No violations found, but MANIFEST integrity was NOT verified here.
  Run 'aahp verify', which blocks when integrity cannot be established.
```

`doctor` never received that treatment. This pull request gives it to the one gate that
needed it, and makes the single configuration with real consequences explicit.

## What changed

| File | Change |
|---|---|
| `bin/aahp.js` | `gateHandoffSet`'s pass reason now reads `N indexed files present, no strays (content not compared; aahp verify Layer 1 owns checksum integrity)`. A header comment states the ADR-011 boundary, says that `aahp lint` is not a substitute for Layer 1 and why, names the one configuration where the boundary has consequences, and names the limit of the wording itself. Comments only apart from the reason string. |
| `README.md` | New subsection "What `doctor` does not check: handoff file content", the seven-gate summary now says "file content not compared", and the section states the limit of the change and the interpreter dependency of `aahp lint`. |
| `CHANGELOG.md` | Three entries under `[Unreleased] / Changed`. (Corrected during pre-merge review: this row said "Two"; `git diff 8906444..HEAD -- CHANGELOG.md \| grep -c "^+- "` returns 3.) |
| `assets/governance/aahp-govern.yml` | Header now states that this workflow runs no handoff-integrity gate, that neither of its own two steps stands in for one, and that `aahp lint` cannot stand in for one in a workflow that sets up Node and not Python. Comment only; the workflow itself is unchanged. (Row added during pre-merge review: this file is one of the seven changed and the only one that ships into other repositories, and the table omitted it.) |
| `tests/doctor.bats` | Three new tests, described below. |
| `.ai/handoff/STATUS.md`, `.ai/handoff/MANIFEST.json` | Handoff state moved with the code, as the Layer 2 drift gate requires. `MANIFEST.json` carries the recomputed `STATUS.md` checksum (CR stripped, the way `scripts/_aahp-lib.sh` computes it) and line count (`wc -l`). |

## What deliberately did NOT change

Option B from the issue (make `gateHandoffSet` compare recorded checksums) is
**rejected**, and one of the new tests exists to keep it rejected:

- It would duplicate `aahp verify` Layer 1.
- It would contradict ADR-011 and ADR-012.
- It would silently change what an already-recorded green conformance record means for
  every adopter that has ingested one.

The `schemaVersion: 1` record is also untouched. It carries gate statuses and no
reasons, so a wording change cannot reach it.

## The narrow configuration this actually affects, now explicit

Measured, not assumed: on this repository, and in any repository whose
`aahp-verify.yml` matches the shipped one, the impact is **nothing**.
`.github/workflows/aahp-verify.yml` runs `bash scripts/verify-handoff.sh . --level ci`
and then `node bin/aahp.js doctor . --json` in the same job. `grep -c "if:"` and
`grep -c "continue-on-error"` over that file both return 0, so a checksum drift fails
the job at the verify step and the doctor step never executes.

Real exposure exists in exactly one configuration, and both the source and the README
now name it: a repository where `verify-workflow` reports `skip` (nothing there runs the
AAHP verify gate) while the handoff gates are evaluated. In that repository no
automated gate compares a handoff checksum, `aahp doctor` exits 0, `aahp check` exits
0, and until this change nothing in the green record said so.

## Limits of this change, stated plainly

The behaviour is unchanged by design, and so is the reach of the new wording. Both are
now written into the source comment, the README and the CHANGELOG so they survive the
merge, and both are limits rather than completed fixes.

**The behaviour still permits what it permitted.** `aahp doctor` and `aahp check` still
exit 0 with every gate green on a drifted handoff set. Making either go red is Option B,
rejected above.

**The new sentence reaches ONE surface, and it is not the surface consumers ingest.**
On the same drifted tree, same commit:

| invocation | `handoff-set` line | exit |
|---|---|---|
| `aahp doctor .` | `PASS handoff-set: ... (content not compared; ...)` | 0 |
| `aahp doctor . --json` | statuses only, no reason field | 0 |
| `aahp doctor . --quiet` | nothing printed at all | 0 |
| `aahp doctor . --governance --json` | `"handoff-set": "skip"` | 0 |

Those last three are the invocations wired into CI and hooks:
`.github/workflows/aahp-verify.yml` runs `doctor . --json`,
`assets/governance/aahp-govern.yml` runs `doctor --governance --json`, and
`scripts/hooks/pre-push` runs `doctor --quiet`, where `bin/aahp.js` suppresses passing
lines. The new wording therefore reaches a person typing `aahp doctor` by hand, and
this repository's own `npm run doctor` in `ci.yml`, but **not** the repository that
treats the `schemaVersion: 1` record as its handoff-integrity signal, which is the
party the reproduction identified as exposed. Holding that record byte-identical is a
deliberate compatibility choice for dashboards that already ingest it. Changing it is a
`schemaVersion` decision, and it is the owner decision left open below.

## Commits

- `dc2ece7` on `docs/doctor-names-what-it-did-not-compare`, branched from
  `890644444d62b10ae39c4fd748577664795eebd4` on `main`. The implementing commit.
- `55e64e0`, the pre-merge review repairs described above.

Branch against `8906444`: seven files, 224 insertions, 11 deletions.
`git status --porcelain` is empty after both commits.

## Mutation proof, taken on the implementing commit `dc2ece7`

Two mutations, each aimed at one specific test, each proved to have LANDED before the
run by re-reading the file from disk and counting a marker for the mutated form and a
marker for the original form. Every step is sequenced with `;`, never `&&`, so a failed
edit cannot be reported as the test runner's exit code. Exit codes are asserted as exact
values, not as "non-zero".

**Read the hash table below as a statement about `dc2ece7`, not about HEAD.** The repair
commit `55e64e0` edits comment lines in `bin/aahp.js`, so these values no longer describe
the file at HEAD; the current content hashes to
`05e7397b0c2b9b5c98141612cbe9f3affb0758a983bd3e1123f0ec705c401f98` with CR stripped. No
executable line moved, the emitted reason string is byte-identical, and CI on `55e64e0`
runs the three tests green, which is stated with its log below.

| state | sha256 of `bin/aahp.js` |
|---|---|
| fix applied | `d34fd3eb97963e021cfd454eee03eb3157f9854a6101d3ada4b689480836ddef` |
| mutation A applied | `77e7c592b74e15b628ba4aa3101f672d1cc6378391d013a68d36cec88ae7a6bf` |
| mutation A restored | `d34fd3eb97963e021cfd454eee03eb3157f9854a6101d3ada4b689480836ddef` (identical) |
| comment wording corrected, this is the content committed in `dc2ece7` | `1f53593e800788b19478c889b5900abc0de6392156a252f6b61d03b9709cdd0a` |
| mutation B applied | `157f0f42aabe2f74aeed73a4ed494c5516b074a5e611fdb03105384eb9f7b973` |
| mutation B restored | `1f53593e800788b19478c889b5900abc0de6392156a252f6b61d03b9709cdd0a` (identical) |

### Mutation A: put the pass reason back to its pre-fix wording

Proof that it landed, read back from disk after the edit:

```
STATE OF bin/aahp.js AFTER APPLY OF MUTATION A
  mutant marker   'no strays` }'                           count=1
  original marker "' (content not compared; aahp verify Layer 1 owns checksum integrity)'" count=0
  CRLF=1087 LF=1087 (equal means the file is still CRLF)
  sha256=77e7c592b74e15b628ba4aa3101f672d1cc6378391d013a68d36cec88ae7a6bf
  POSTCONDITION OK: expected (1, 0), got (1, 0)

-- independent re-read, separate command --
no strays` }         -> 1
content not compared -> 0
node --check bin/aahp.js exit=0
```

**RED**, verbatim:

```
1..1
not ok 1 doctor: the handoff-set pass reason names the content check it did not run
# (in test file tests/doctor.bats, line 291)
#   `[[ "$output" == *"no strays (content not compared; aahp verify Layer 1 owns checksum integrity)"* ]]' failed
BATS EXIT WITH MUTATION A APPLIED = 1
```

Exit code asserted as exactly **1**, and the failing line is the substring assertion
itself, at `tests/doctor.bats:291`, not some other error path.

**RESTORE**, verbatim:

```
STATE OF bin/aahp.js AFTER RESTORE OF MUTATION A
  mutant marker   'no strays` }'                           count=0
  original marker "' (content not compared; aahp verify Layer 1 owns checksum integrity)'" count=1
  CRLF=1092 LF=1092 (equal means the file is still CRLF)
  sha256=d34fd3eb97963e021cfd454eee03eb3157f9854a6101d3ada4b689480836ddef
  POSTCONDITION OK: expected (0, 1), got (0, 1)
```

### Mutation B: make `gateHandoffSet` compare recorded checksums (Option B)

The mutation adds a `node:crypto` import and a real checksum comparison to the gate,
returning `fail` on a mismatch. This is the change ADR-011 rejects, and the second test
exists to catch it.

Proof that it landed:

```
STATE OF bin/aahp.js AFTER APPLY OF MUTATION B
  mutant marker   'MUTANT checksum mismatch'               count=1
  original marker "import { createHash } from 'node:crypto'" count=1
  CRLF=1102 LF=1102 (equal means the file is still CRLF)
  sha256=157f0f42aabe2f74aeed73a4ed494c5516b074a5e611fdb03105384eb9f7b973
  POSTCONDITION OK: expected (1, 1), got (1, 1)

-- independent re-read, separate command --
no strays` }             -> 0
content not compared     -> 1
MUTANT checksum mismatch -> 1
node:crypto              -> 1
node --check bin/aahp.js exit=0
```

`node --check` is part of the proof: a mutation that broke the syntax would redden the
test for the wrong reason and would have to be discarded.

**RED**, verbatim:

```
1..1
not ok 1 doctor --json: handoff-set stays pass on content drift (ADR-011 boundary, not scope creep)
# (in test file tests/doctor.bats, line 297)
#   `[ "$status" -eq 0 ]' failed
BATS EXIT WITH MUTATION B APPLIED = 1
```

Exit code asserted as exactly **1**.

**RESTORE**, verbatim:

```
STATE OF bin/aahp.js AFTER RESTORE OF MUTATION B
  mutant marker   'MUTANT checksum mismatch'               count=0
  original marker "import { createHash } from 'node:crypto'" count=0
  CRLF=1093 LF=1093 (equal means the file is still CRLF)
  sha256=1f53593e800788b19478c889b5900abc0de6392156a252f6b61d03b9709cdd0a
  POSTCONDITION OK: expected (0, 0), got (0, 0)
```

### GREEN, on the exact content that was committed in `dc2ece7`

```
bin/aahp.js under test, sha256 = 1f53593e800788b19478c889b5900abc0de6392156a252f6b61d03b9709cdd0a
1..3
ok 1 doctor: the handoff-set pass reason names the content check it did not run
ok 2 doctor --json: handoff-set stays pass on content drift (ADR-011 boundary, not scope creep)
ok 3 doctor drift fixture: aahp verify DOES see the drift (guard for the two tests above)
BATS EXIT WITH BOTH MUTATIONS RESTORED = 0
```

The independent pre-merge review reproduced both mutations from a fresh clone and got
exit code exactly 1 for each, and `BATS_EXIT_RESTORED=0` on the restored file.

### One environment caveat, recorded rather than hidden

Several unrelated Bats suites were running on the same Windows box while this proof was
taken. One `npx bats` invocation produced NO TAP output at all and still exited 0, while
MSYS was failing to fork. Every result above is therefore accepted only when the TAP
plan line and an `ok`/`not ok` line are BOTH present, never on an exit code alone. A
filter sanity check was run separately for the same reason:

```
npx bats tests/doctor.bats -f "did not run" --count      -> 1
npx bats tests/doctor.bats -f "ADR-011 boundary" --count -> 1
```

so neither red run could have been an empty selection reporting success. The same
failure mode recurred on the repair commit: a filtered local run of the three tests
produced no TAP output at all and exited 255 under load, and is therefore reported as
NO RESULT rather than as a pass. The hosted Linux CI run on `55e64e0` below is the
verdict, and it is a stronger one: it ran the whole suite on the exact commit.

## Verification: the original reproduction, re-run on the fixed tree

The recipe in the issue, run unchanged against `dc2ece7`. Working tree clean before and
after. The repair commit changes no executable line, so this observation still holds at
HEAD; the `handoff-set` line below was re-observed on `55e64e0`, byte for byte.

```
HEAD = dc2ece7bc7ec22f40698516e70219d80224e182c
branch = docs/doctor-names-what-it-did-not-compare
working tree before (empty means clean):

===== BASELINE, no drift =====
baseline doctor exit=0

===== APPLY THE SAME DRIFT THE ISSUE APPLIES =====
recorded checksum in MANIFEST.json:
  sha256:776bd5ef368c02cc5102bb284757b28b9480f79a2847e0c955d4ec907180d0de
checksum of the bytes on disk, computed the way AAHP does (CR stripped):
  sha256:018e76865fdb94d2087c05a832eb169010e5327fc80b17450310f61d95fffbf6

===== doctor ON THE DRIFTED TREE, AFTER THE FIX =====

aahp doctor -conformance for homeofe/AAHP (aahp v3.10.0)
=========================================
  PASS     handoff-set: 11 indexed files present, no strays (content not compared; aahp verify Layer 1 owns checksum integrity)
  PASS     manifest-schema: structural checks against aahp-manifest.schema.json pass
  PASS     grounding: GROUNDING.md present; TRUST.md has a Provenance column
  SELF     pinned-dep: this repo is @elvatis_com/aahp itself
  PASS     changelog-format: Keep a Changelog format valid
  PASS     version-sync: version matches 1 site(s)
  PASS     verify-workflow: the gate runs unconditionally at --level ci (.github/workflows/aahp-verify.yml:aahp-verify)
=========================================
Conformance OK: 7 gate(s), no failures.

JSON record:
{"schemaVersion":1,"repo":"homeofe/AAHP","aahpVersion":"3.10.0","gates":{"handoff-set":"pass","manifest-schema":"pass","grounding":"pass","pinned-dep":"self","changelog-format":"pass","version-sync":"pass","verify-workflow":"pass"},"checkedAt":"2026-08-22T14:24:40.551Z"}
doctor exit=0

===== check ON THE IDENTICAL TREE =====
  PASS   doc-links: Doc links OK: 17 internal file link(s) resolve.
  PASS   handoff: Handoff generator OK: no LOG generation configured; NEXT_ACTIONS current-version matches package.json.
=========================================
Governance OK: 7 gate(s) ran, no failures.
check exit=0

===== verify ON THE IDENTICAL TREE (the guard) =====

=========================================
  AAHP Verify (level: precommit)
=========================================

[Layer 1] MANIFEST integrity: indexed files present and unchanged
  FAIL: MANIFEST.json checksums do not match file contents. Run /handoff.
    Checksum mismatch: STATUS.md
      Expected: sha256:776bd5ef368c02cc5102bb284757b28b9480f79a2847e0c955d4ec907180d0de
      Actual:   sha256:018e76865fdb94d2087c05a832eb169010e5327fc80b17450310f61d95fffbf6

[Layer 2] Content-drift gate (code changed => handoff must change)
  OK: No handoff-impacting files changed outside .ai/handoff/. Drift gate not triggered.

=========================================
  aahp verify FAILED: 1 blocking issue(s) (level: precommit).
  Run /handoff to refresh STATUS.md + MANIFEST.json, then retry.
=========================================
verify exit=1

===== RESTORE =====
working tree after (empty means clean):
REPRO SCRIPT DONE
```

That `verify` failure is the guard. It proves the drift genuinely applied, so `doctor`'s
green above is a real observation and not a mutation that never landed.

### Can the original finding still be reproduced?

**The behaviour is unchanged, deliberately, and that is not the defect being fixed.**
`aahp doctor` still exits 0 with every gate `pass` on a drifted handoff set, and so does
`aahp check`. Anyone who runs the issue's recipe expecting a non-zero exit will still
see 0, and that is the documented design in ADR-011.

**The defect, as the reproduction narrowed it, no longer reproduces on the surface the
change reaches.** The finding that survived checking is that doctor's output says
nothing about what it did not verify, so a green `handoff-set` line reads as an
integrity verdict. On the identical drifted tree:

| | `handoff-set` line |
|---|---|
| before, at `890644444d62b10ae39c4fd748577664795eebd4` | `PASS     handoff-set: 11 indexed files present, no strays` |
| after | `PASS     handoff-set: 11 indexed files present, no strays (content not compared; aahp verify Layer 1 owns checksum integrity)` |

The "before" line is quoted from a run of the same recipe on the same machine against
`main` at `8906444`, before any change was made, and it was reproduced independently by
the pre-merge review by mutating the fix away. Which surfaces carry the "after" line and
which do not is stated under "Limits of this change" above.

**And the record consumers ingest did not move.** The `--json` gate map above is
byte-identical to the one the issue quotes: same seven keys, same seven values, same
`schemaVersion: 1`. Reasons live only in the human-readable output, so no dashboard sees
a change, which is also why no dashboard sees the new sentence.

## Hosted Linux CI on `55e64e0`, the authoritative full-suite result

Every check on the current head concluded `pass`; nothing is pending and nothing is
skipped except the release jobs, which are not meant to run on a pull request.

```
Analyze (javascript-typescript)  pass  1m0s
CodeQL                           pass  2s
Runtime matrix (22)              pass  1m46s
Runtime matrix (24)              pass  1m43s
aahp-archive                     pass  6s
aahp-lint                        pass  5s
aahp-manifest                    pass  9s
aahp-pii-allowlist               pass  6s
aahp-verify                      pass  7s
lint-and-validate                pass  1m57s
Create GitHub Release            skipping
Publish to npm                   skipping
```

The job LIST matters here, not the colour. `lint-and-validate` is the one that runs
`npm run check` and the whole Bats suite, and its log on `55e64e0` shows the suite really
executed and really contains the three new tests:

```
1..408
ok 180 doctor: the handoff-set pass reason names the content check it did not run
ok 181 doctor --json: handoff-set stays pass on content drift (ADR-011 boundary, not scope creep)
ok 182 doctor drift fixture: aahp verify DOES see the drift (guard for the two tests above)
```

`aahp-verify` is the required handoff gate, and its passing on `55e64e0` is the
independent confirmation that the `MANIFEST.json` entry committed here matches the bytes
committed with it.

### On the manifest entry

`.ai/handoff/MANIFEST.json` was updated surgically rather than regenerated: only
`STATUS.md` changed, so only its `checksum`, `lines` and `updated` moved, which keeps the
diff small and leaves `last_session` and every other entry alone. The checksum was
computed the way `scripts/_aahp-lib.sh` computes it (CR stripped before hashing) and the
line count the way `aahp_line_count` does (`wc -l`). `aahp verify --level ci` passing on
Linux is the independent check on that.

## Tests added

Three tests in `tests/doctor.bats`, all built on one helper, `scaffold_drifted_handoff`,
which scaffolds a conformant consumer fixture and then rewrites `STATUS.md` content
WITHOUT regenerating `MANIFEST.json`. Byte length and line count are preserved on
purpose, so the content hash is the only thing that differs from the recorded entry and
no other gate has a second reason to notice.

| Test | What it pins | The single line a reviewer deletes to redden it |
|---|---|---|
| `doctor: the handoff-set pass reason names the content check it did not run` | the new wording is actually emitted | `[[ "$output" == *"no strays (content not compared; aahp verify Layer 1 owns checksum integrity)"* ]]` |
| `doctor --json: handoff-set stays pass on content drift (ADR-011 boundary, not scope creep)` | the ADR-011 boundary, against silent scope creep into Option B | `[ "$status" -eq 0 ]` (corrected during pre-merge review: the JSON line `if (r.gates["handoff-set"] !== "pass") process.exit(2);` originally named here is NOT what reddens this test. Deleting it with Option B applied still fails, at `tests/doctor.bats:297`, on the status assertion, which the mutation section of this body already reported. In this fixture `fail` and `missing` both drive doctor to exit 1 and `skip` is unreachable without `--governance`, so the JSON assertion restates the status assertion) |
| `doctor drift fixture: aahp verify DOES see the drift (guard for the two tests above)` | that the fixture is genuinely drifted | `[[ "$output" == *"Checksum mismatch: STATUS.md"* ]]` |

The third test is the one that makes the other two mean anything. Without it, a fixture
whose drift never applied would let both of the first two pass while proving nothing.

Before this change, `tests/doctor.bats` had 16 tests and none exercised content drift.
That absence was checked rather than assumed: the only occurrence of `checksum` in the
file was an all-zero placeholder inside the fixture for the unrelated "indexed file is
missing on disk" test, and the positive control for the same search on the same file,
`grep -c "handoff-set" tests/doctor.bats`, returned 9.

## What was run locally, and what was not

The full suite was deliberately NOT run on Windows: process spawning there makes a full
Bats pass take hours and produces no verdict Linux CI does not produce better. On the
implementing commit, only the three new tests in `tests/doctor.bats` were run, filtered,
and they are the mutation proof above. On the repair commit the same filtered run
returned no TAP output at all and exit 255 under load, so it is reported as NO RESULT.
The hosted Linux CI run on `55e64e0` is the authoritative full-suite result and it is
quoted above with its plan line and the three test names.

## Not fixed, deliberately

- **`gateHandoffSet` still does not compare checksums.** That is Option B, and it is
  rejected for the three reasons above. One of the new tests exists specifically to make
  a future attempt at it go red rather than land quietly. That test converts ADR-011
  from a written decision into a red build, so an owner who later decides Option B is
  right must delete a test whose name says "not scope creep". Disclosed rather than
  hidden.
- **`aahp check` is still green on a drifted tree.** It runs the config-driven
  governance gates, not the handoff integrity gate, which is what ADR-011 says. This is
  recorded here because the original issue did not mention it, not because it is a
  second defect.
- **The `schemaVersion: 1` record is unchanged, and so is what a dashboard sees.** No
  new field, no new status, no changed status, and no statement about what was not
  compared. That is the residual gap, it is stated in the source and in README, and it
  is the subject of the open owner decision below.

## Open owner decision, not taken here

The reproduction left exactly one semantics question for the owner, and this pull
request deliberately does not answer it:

> When `verify-workflow` reports `skip` AND the handoff gates were evaluated, the record
> is green while nothing in that repository ever compares a checksum. Whether `doctor`
> should say so more loudly in that specific combination, or leave it to the adopter, is
> a semantics call for the owner.

What this pull request does instead is make the situation explicit in three places a
reader will actually meet it: the pass reason on every default run, the README, and the
header of the governance workflow that `aahp init --gates` scaffolds into consumers. It
adds no conditional output and no new failure mode, so the owner's decision stays open
and unprejudiced. It is tracked at https://github.com/homeofe/AAHP/issues/72.

## Issue housekeeping

https://github.com/homeofe/AAHP/issues/72 has been retitled and relabelled to match the
evidence (`bug` to `documentation`, `priority: medium` to `priority: low`), its body
corrected, and the original text preserved verbatim in a collapsed block at the bottom.
**The issue is left OPEN for owner review.** This pull request does not close it.

## Checklist

- [x] Tests pass. The three new tests in `tests/doctor.bats` are green in the hosted
      Linux CI run on `55e64e0`, inside a `1..408` plan, quoted above with their names.
      A filtered local Windows run on the repair commit produced no TAP output and is
      reported as NO RESULT rather than as a pass.
- [x] Documentation updated (README, CHANGELOG, the header of the scaffolded governance
      workflow, and the source comment on the gate itself), and every claim in those
      four surfaces was re-verified against the code during pre-merge review.
- [x] No secrets in the commit history
- [x] Behaviour unchanged, which is the point of this change rather than an omission
- [ ] **The `schemaVersion: 1` record still carries no statement about what was not
      compared**, so a repository that reads it as a handoff-integrity signal gains
      nothing from this change. Deliberate, for compatibility with dashboards that
      already ingest the record, and now stated in `bin/aahp.js`, in README and in
      CHANGELOG rather than only here. Changing it is a `schemaVersion` decision and is
      tracked as the open owner decision at https://github.com/homeofe/AAHP/issues/72.
