### PR TITLE
fix(ci): assert one release definition and record every publish condition

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,9 +11,9 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:52df38cc949bb0d3d40ce26b8651b41d7e31a7afe839377afc6ed3f6b20f6953",
-      "updated": "2026-08-22T18:00:09Z",
-      "lines": 118,
+      "checksum": "sha256:0bb2cfad095d6bc987b3821f0a10f23c876bcaf93af6da0fdf9229808e8a632b",
+      "updated": "2026-08-22T21:32:06Z",
+      "lines": 131,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
@@ -80,8 +80,8 @@
   "quick_context": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 4557,
-    "full_read": 14627
+    "manifest_plus_core": 4922,
+    "full_read": 14992
   }
   ,"next_task_id": 18
   ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -46,6 +46,16 @@ its gate now reports it on its own pull requests. It is asserted as a CONSEQUENC
 ("there exists an event on which this workflow concludes success without having run
 the gate at `--level ci`"), it fails closed on a shape it cannot classify, and it was
 measured against every consumer of this protocol before shipping.
+
+Release authorization in `ci.yml` is now asserted. The `publish` job (npm,
+`id-token: write`) and the `release` job (the GitHub Release) each carried a
+hand-written `if:`, the two disagreed about what counts as a release, and nothing in
+this repository read either one, so the drift was invisible and any later edit to
+publish authorization would have been equally silent. The release definition is now
+written once and both jobs must use exactly it; every additional top-level `||`
+operand on the publish condition must appear in a literal recorded list. No workflow
+behaviour changes: whether the `workflow_dispatch` operand should exist at all is the
+owner's decision and is recorded as open, with its options, in ADR-019.
 <!-- /SECTION: summary -->
 
 ---
@@ -67,6 +77,7 @@ measured against every consumer of this protocol before shipping.
 | shellcheck | LINUX PASS | replacement head `c332a23` reached the full Bats step after shellcheck |
 | hosted Linux suite | REPLACEMENT REQUIRED | `c332a23` passed 361/362; the CI mode fixture let `git add` restore mode 100644 on Linux, so it now reasserts 100755 before its content-plus-mode commit |
 | full Bats suite | CI | deliberately not run on Windows; Linux CI is authoritative |
+| `tests/runtime-support.bats` (release authorization) | FOCUSED PASS | 8/8 added; the untouched repository shape is green, six one-line mutations of the REAL `ci.yml` each turn it red at exit 1 (including a publish job with no `if:` at all), and a reformat of the same expression stays green |
 <!-- /SECTION: build_health -->
 
 ---
@@ -88,6 +99,7 @@ measured against every consumer of this protocol before shipping.
 | Runtime matrix | `.github/workflows/ci.yml` | Changed | new `runtime-matrix` job on Node 22 and 24; `lint-and-validate` deliberately left unmatrixed so the required check keeps its literal name |
 | verify-workflow gate | `scripts/check-verify-workflow.mjs` | New | audits the consumer's workflows for a gate that can skip itself; zero runtime dependencies, so it carries its own block-YAML reader, held against a real parser by `tests/assert-workflow-parser-parity.mjs` |
 | Release surfaces | `package*.json`, `CHANGELOG.md` | Changed | v3.10.0 prepared, workflow included in npm artifact, not released; `engines.node` now `>=22`, `yaml` added as a devDependency |
+| Repo-shape assertion | `tests/assert-repo-ci-shape.mjs` | Changed | third assertion: `publish` and `release` share ONE release definition, and every publish operand beyond it is recorded literally; reads the parsed condition, runs inside the required `lint-and-validate` |
 <!-- /SECTION: components -->
 
 ---
@@ -107,6 +119,7 @@ measured against every consumer of this protocol before shipping.
 | `aahp-verify` can skip itself in six consumers | HIGH | ORIGINATED HERE. `458dbbd` (2026-06-30) added the dependency-bot exemption to this repository's own reference workflow, gating Checkout and every gate step; it shipped that way in v3.6.0 and propagated. `#65` removed it here on 2026-08-21. MEASURED 2026-08-22 with the new `verify-workflow` gate, against every consumer: six report `bypassable`, three report `enforced`. Five of the six report success having checked out nothing, so Layer 1 never runs either. The sixth was previously recorded here as corrected and is only PARTLY so: its checkout is unconditional and a bot change does get a Layer 1 run, but `--level ci` is still gated on the author, so the same required check name means all four layers for one author and Layer 1 for another. Only the owning repositories can re-propagate; this branch cannot fix any of them. Consumer identities are tracked privately and deliberately not recorded in this public repository. |
 | No drift check between a consumer's propagated workflow and the installed package | PARTLY CLOSED | `aahp doctor` still never compares `.github/workflows/aahp-verify.yml` on disk against the one in the installed package, so a consumer can pin 3.10.0 and run the v3.6.0 workflow. The designed predicate this row asked for now exists for the case that matters: `verify-workflow` asks whether the hosting workflow can skip the gate, which tolerates deliberate divergence (a consumer may restructure the file freely) while catching the divergence that voids the check. General byte-level drift, for example an older action pin or a dropped `fetch-depth: 0`, is still unmeasured. |
 | Consumer manifests already rewritten | MEDIUM | The generator no longer writes a checkout's directory name into `project`, but repositories whose committed `MANIFEST.json` already carries such a name keep it, because a recorded name is preserved by design. Those values need correcting in the consumer repositories. |
+| Manual publish path on the `ci.yml` `publish` job | NORMAL | OPEN OWNER DECISION, deliberately not taken here. The publish condition still accepts `workflow_dispatch`, which constrains no ref, so a manual run publishes from whichever ref it started on with no tag and no GitHub Release. Options A, B and C, and what each one requires, are in ADR-019. The condition is now pinned, so adopting any of them is a visible two-part edit rather than a silent one. |
 <!-- /SECTION: what_is_missing -->
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,21 @@ jobs:
     # Both gates, so a release cannot ship past a red runtime matrix.
     needs: [lint-and-validate, runtime-matrix]
     runs-on: ubuntu-latest
+    # Release authorization. This condition has two top-level operands and they
+    # are different kinds of thing.
+    #
+    # The first is the shared definition of "this ref is a release". It is
+    # byte-identical to the `release` job's condition below, and
+    # tests/assert-repo-ci-shape.mjs holds the two together, so they cannot
+    # drift apart unnoticed the way they did before.
+    #
+    # The second is a standing permission to publish on something that is not a
+    # release: a manual run publishes from whichever ref it was started on, with
+    # no tag and no GitHub Release. Whether that path should exist at all is an
+    # OPEN owner decision, recorded with its options in ADR-019 in README.md and
+    # tracked at https://github.com/homeofe/AAHP/issues/69. Until it is settled,
+    # the same assertion pins this condition exactly as written, so any edit to
+    # it must update the record in the same commit.
     if: (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')) || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
@@ -140,6 +155,8 @@ jobs:
     name: Create GitHub Release
     needs: publish
     runs-on: ubuntu-latest
+    # The shared release definition, byte-identical to the first operand of the
+    # publish condition above. Asserted by tests/assert-repo-ci-shape.mjs.
     if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ independently of the npm version).
 ## [Unreleased]
 
 ### Added
+- `tests/assert-repo-ci-shape.mjs` asserts release authorization in `ci.yml`. The
+  `publish` job (npm, `id-token: write`) and the `release` job (the GitHub Release) each
+  carried a hand-written `if:`; the two disagreed about what counts as a release, and
+  nothing in this repository read either one, so the disagreement was invisible and a
+  later edit to publish authorization would have been equally silent. The release
+  definition is now written once and both jobs must use exactly it, and every additional
+  top-level `||` operand on the publish condition must appear in a literal recorded list.
+  The assertion reads the PARSED condition rather than a substring, so reformatting the
+  workflow changes no verdict, and a job with no `if:` at all is a failure rather than a
+  pass. It runs inside the required `lint-and-validate` check. No workflow behaviour
+  changes here: whether the `workflow_dispatch` operand should exist at all is the
+  owner's call and is recorded as open, with its options, in ADR-019.
 - `aahp doctor` gains a `verify-workflow` gate that answers, from inside a consumer,
   whether the workflow hosting the AAHP gate can skip it. Wrapping the `aahp-verify`
   job in an `if:`, or wrapping the gate step inside it, leaves a REQUIRED status check

--- a/README.md
+++ b/README.md
@@ -934,6 +934,35 @@ or force-push cannot select HEAD as its own merge base. Layer 1 runs for every a
 maintenance changes avoid unrelated handoff churn without creating an identity bypass,
 path-pattern bypass, or vacuous required check.
 
+### ADR-019: one release definition, and publish authorization is machine-asserted
+**Why it recurs:** `.github/workflows/ci.yml` has two release-critical jobs: `publish`,
+which runs `npm publish --access public --provenance` with `id-token: write`, and
+`release`, which creates the GitHub Release for the same ref. Each carried its own
+hand-written `if:`, so the two answered "is this a release?" differently and the looser
+of the two was the one wired to the public registry. Nothing in the repository read
+either condition, so the disagreement was invisible, and any later edit to publish
+authorization would have been equally silent.
+**Decision:** the release definition `startsWith(github.ref, 'refs/tags/v') &&
+contains(github.ref, '.')` is written ONCE, as `RELEASE_REF_CONDITION` in
+`tests/assert-repo-ci-shape.mjs`. Both jobs must use exactly it, and every additional
+top-level `||` operand on the publish condition must appear in
+`PUBLISH_CONDITIONS_BEYOND_RELEASE` in the same file. The assertion reads the PARSED
+condition rather than a substring of the workflow, so reformatting changes no verdict,
+and it runs inside the required `lint-and-validate` check, so an unrecorded change to
+publish authorization cannot merge. A job with no `if:` at all is a failure rather than
+a pass: it would run on every event the workflow accepts.
+**Deliberately still open:** whether the `workflow_dispatch` operand on the publish
+condition should exist at all. It permits a publish from any ref, producing no tag and
+no GitHub Release, for a principal who can already push a release tag; none of this
+workflow's 147 runs, measured 2026-08-22, was a manual dispatch. Three options, all
+defensible: (A) delete the operand, leaving the two conditions identical; (B) keep a
+manual path but require a release tag ref on it as well, and put the job behind an
+`environment:` that carries at least one required reviewer, since an environment with no
+protection rule adds a label and no control; (C) keep it and record what compensates for
+it. Adopting any of them means editing the workflow and the recorded list together, and
+the assertion is what forces the pair. Tracked at
+https://github.com/homeofe/AAHP/issues/69.
+
 ---
 
 *The v2-proposal questions below were resolved earlier and are retained for detail.*

--- a/tests/assert-repo-ci-shape.mjs
+++ b/tests/assert-repo-ci-shape.mjs
@@ -7,7 +7,7 @@
 // MODULE_NOT_FOUND and the test reports a defect that does not exist. A path
 // passed as an argv element IS converted, so the repo root arrives here intact.
 //
-// Two things are asserted, and neither is about the gate's own logic:
+// Three things are asserted, and none of them is about a gate's own logic:
 //
 //   1. The runtime-support gate is actually INVOKED by the aggregate `check`
 //      chain. A gate that exists but never runs protects nothing.
@@ -16,6 +16,15 @@
 //      its checks to 'lint-and-validate (22)' and the required context then never
 //      reports again - every pull request blocked, with zero red checks to
 //      explain why. The second runtime therefore belongs in runtime-matrix.
+//   3. The two release-critical jobs in ci.yml share ONE definition of "this ref
+//      is a release", and the publish job carries no unrecorded permission to run
+//      beyond it. See section 3 below for why, and for what is deliberately left
+//      open.
+//
+// Exit codes: 0 when every assertion holds, 1 when at least one does not. There
+// is no third code and no skip: an input this file cannot read is reported as a
+// failure, because "I could not look" must never read as "I looked and it was
+// fine".
 
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -55,6 +64,304 @@ if (!ci?.jobs?.["runtime-matrix"]) {
       "longer be exercised at more than one point.",
   );
 }
+
+// ─── 3. One definition of a release, and no unrecorded path to npm publish ───
+//
+// ci.yml has two release-critical jobs. `publish` runs `npm publish --access
+// public --provenance` with `id-token: write`; `release` creates the GitHub
+// Release for the same ref. Each carried its own hand-written `if:`, and the two
+// drifted: `publish` additionally accepted `workflow_dispatch`, an operand that
+// constrains no ref at all, so two jobs in one file answered "is this a release?"
+// differently and the looser answer was the one wired to the public registry.
+//
+// The drift is not the part that mattered. NOTHING in this repository read either
+// condition, so the disagreement was invisible and any future edit to publish
+// authorization would have been equally silent. This section is the missing
+// reader. Reported at https://github.com/homeofe/AAHP/issues/69.
+//
+// It is a CHANGE DETECTOR, not a policy. It does not decide whether a manual
+// publish path should exist; that question is recorded as open in ADR-019 in
+// README.md. What it does is pin both conditions to the state this repository has
+// recorded, so changing either one becomes a two-part edit - the workflow and the
+// record below - that a reviewer meets in a single diff.
+//
+// It reads the PARSED condition from the YAML, never a substring of the file, so
+// reformatting the workflow cannot turn the assertion green or red on its own.
+
+// The single definition of "this ref is a release", written once. Both jobs must
+// use exactly this expression. That is the half of issue 69 which is not a policy
+// question: two jobs in one file must not disagree about what a release is.
+const RELEASE_REF_CONDITION =
+  "startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')";
+
+// Top-level `||` operands that jobs.publish.if carries BEYOND the shared release
+// definition, written exactly as recorded in the comment above that condition in
+// ci.yml. Each entry is a standing permission to publish to npm on something that
+// is not a release tag, so this list is deliberately literal: no patterns, no
+// wildcard entry, and an empty list is a meaningful state rather than "unchecked".
+//
+// One entry today, and it is an OPEN owner decision rather than a settled one.
+// A manual run publishes from whatever ref it was started on, producing no tag and
+// no GitHub Release; none of this workflow's 147 runs, measured 2026-08-22, was a
+// manual dispatch. The options for settling it, and what each one requires, are in
+// ADR-019. Adopting any of them means editing ci.yml and this list in the same
+// commit, which is the entire point of the list.
+const PUBLISH_CONDITIONS_BEYOND_RELEASE = [
+  "github.event_name == 'workflow_dispatch'",
+];
+
+/**
+ * Collapse every run of whitespace outside single-quoted literals to one space.
+ * Actions expressions quote with `'` and escape a quote by doubling it, so a
+ * literal is left byte-for-byte intact; collapsing inside one would change what
+ * the expression means. Returns null on an unterminated literal.
+ */
+function collapseOutsideLiterals(expr) {
+  let out = "";
+  let inLiteral = false;
+  for (let i = 0; i < expr.length; i += 1) {
+    const c = expr[i];
+    if (inLiteral) {
+      out += c;
+      if (c === "'") {
+        if (expr[i + 1] === "'") {
+          out += "'";
+          i += 1;
+        } else {
+          inLiteral = false;
+        }
+      }
+      continue;
+    }
+    if (c === "'") {
+      inLiteral = true;
+      out += c;
+      continue;
+    }
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      if (out.length > 0 && !out.endsWith(" ")) out += " ";
+      continue;
+    }
+    out += c;
+  }
+  return inLiteral ? null : out.trim();
+}
+
+/**
+ * True when the whole expression is one parenthesised group, so that dropping the
+ * first and last character cannot change how it binds. `(a) || (b)` is not, and
+ * must keep its parentheses.
+ */
+function isSingleParenthesisedGroup(expr) {
+  let depth = 0;
+  let inLiteral = false;
+  for (let i = 0; i < expr.length; i += 1) {
+    const c = expr[i];
+    if (inLiteral) {
+      if (c === "'") {
+        if (expr[i + 1] === "'") i += 1;
+        else inLiteral = false;
+      }
+      continue;
+    }
+    if (c === "'") {
+      inLiteral = true;
+      continue;
+    }
+    if (c === "(") {
+      depth += 1;
+    } else if (c === ")") {
+      depth -= 1;
+      if (depth < 0) return false;
+      if (depth === 0) return i === expr.length - 1;
+    }
+  }
+  return false;
+}
+
+/** Drop redundant enclosing parentheses: `(a && b)` becomes `a && b`. */
+function stripEnclosingParens(expr) {
+  let s = expr.trim();
+  while (s.startsWith("(") && s.endsWith(")") && isSingleParenthesisedGroup(s)) {
+    s = s.slice(1, -1).trim();
+  }
+  return s;
+}
+
+/**
+ * The `[start, end)` spans of the top-level `||` operands, or null when the
+ * expression is malformed (unbalanced parentheses, unterminated literal). `||`
+ * inside a parenthesised group or a quoted literal is not a top-level operator.
+ */
+function topLevelOrSpans(expr) {
+  const spans = [];
+  let depth = 0;
+  let inLiteral = false;
+  let start = 0;
+  for (let i = 0; i < expr.length; i += 1) {
+    const c = expr[i];
+    if (inLiteral) {
+      if (c === "'") {
+        if (expr[i + 1] === "'") i += 1;
+        else inLiteral = false;
+      }
+      continue;
+    }
+    if (c === "'") {
+      inLiteral = true;
+      continue;
+    }
+    if (c === "(") {
+      depth += 1;
+    } else if (c === ")") {
+      depth -= 1;
+      if (depth < 0) return null;
+    } else if (c === "|" && expr[i + 1] === "|" && depth === 0) {
+      spans.push([start, i]);
+      start = i + 2;
+      i += 1;
+    }
+  }
+  if (inLiteral || depth !== 0) return null;
+  spans.push([start, expr.length]);
+  return spans;
+}
+
+/**
+ * Split a GitHub Actions `if:` condition into its normalised top-level `||`
+ * operands, or null when it cannot be read. An empty operand (`a || || b`) is
+ * malformed and also yields null.
+ */
+function splitTopLevelOr(expr) {
+  const collapsed = collapseOutsideLiterals(expr);
+  if (collapsed === null) return null;
+  const spans = topLevelOrSpans(collapsed);
+  if (spans === null) return null;
+  const operands = [];
+  for (const [from, to] of spans) {
+    const operand = stripEnclosingParens(collapsed.slice(from, to));
+    if (operand === "") return null;
+    operands.push(operand);
+  }
+  return operands;
+}
+
+/** Normalise a whole condition for comparison, or null when it cannot be read. */
+function normaliseCondition(expr) {
+  const collapsed = collapseOutsideLiterals(expr);
+  if (collapsed === null) return null;
+  return stripEnclosingParens(collapsed);
+}
+
+/** Message for a release job that has stopped using the shared definition. */
+function releaseDefinitionMessage(found) {
+  return (
+    "jobs.release.if is not the recorded release definition.\n" +
+    `      recorded: ${RELEASE_REF_CONDITION}\n` +
+    `      found:    ${found ?? "(unreadable: unterminated quoted literal)"}\n` +
+    "      Both release-critical jobs must answer 'is this a release?' with one " +
+    "expression. If the definition itself is meant to change, change " +
+    "RELEASE_REF_CONDITION in this file and both jobs in ci.yml together."
+  );
+}
+
+/** Message for a publish condition that no longer states the shared definition. */
+function publishShapeMessage(count, operands) {
+  return (
+    "jobs.publish.if does not carry the shared release definition exactly once as " +
+    `a top-level '||' operand (found it ${count} time(s)).\n` +
+    `      recorded: ${RELEASE_REF_CONDITION}\n` +
+    `      found:    ${operands.join("  ||  ")}\n` +
+    "      The publish job is the one that reaches the public registry, so it must " +
+    "state the same release definition the release job states. A differently shaped " +
+    "condition, for example one that ANDs the tag test with an event test, is a " +
+    "deliberate change of policy: make it, then record it here and in ADR-019 in the " +
+    "same commit."
+  );
+}
+
+/** Message for a publish operand this repository has never recorded. */
+function unrecordedOperandMessage(operand) {
+  return (
+    "jobs.publish.if grants a publish on a condition this repository has not " +
+    `recorded: ${operand}\n` +
+    "      Every operand beyond the release definition is a standing permission to " +
+    "publish to npm without a release tag. If it is intended, add it to " +
+    "PUBLISH_CONDITIONS_BEYOND_RELEASE in this file, say in the comment above the " +
+    "condition in ci.yml what compensates for it, and update ADR-019."
+  );
+}
+
+/** Message for a recorded operand the publish condition no longer carries. */
+function recordedOperandGoneMessage(operand) {
+  return (
+    `jobs.publish.if no longer carries a recorded condition: ${operand}\n` +
+    "      Removing it is a tightening, not a defect, but the record has to stay " +
+    "true or the next reader is back to guessing. Delete the entry from " +
+    "PUBLISH_CONDITIONS_BEYOND_RELEASE in this file and settle ADR-019 in the same " +
+    "commit."
+  );
+}
+
+const UNREADABLE_PUBLISH_CONDITION =
+  "jobs.publish.if could not be read: unbalanced parentheses, an unterminated " +
+  "quoted literal, or an empty `||` operand. An unreadable publish condition is a " +
+  "failure here, never a skip.";
+
+const publishJob = ci?.jobs?.publish;
+const releaseJob = ci?.jobs?.release;
+
+if (!publishJob) {
+  problems.push(
+    "the 'publish' job is gone from ci.yml. Publish authorization is asserted here " +
+      "by job name, so renaming or removing that job removes the assertion with it. " +
+      "Rename it here in the same commit.",
+  );
+}
+if (!releaseJob) {
+  problems.push(
+    "the 'release' job is gone from ci.yml. It is the second half of the release " +
+      "definition asserted here; without it nothing holds the publish condition to a " +
+      "shared meaning of 'release'.",
+  );
+}
+
+const publishIf = typeof publishJob?.if === "string" ? publishJob.if : null;
+const releaseIf = typeof releaseJob?.if === "string" ? releaseJob.if : null;
+
+if (publishJob && publishIf === null) {
+  problems.push(
+    "jobs.publish has no `if:` condition. That job runs `npm publish --access " +
+      "public --provenance` with id-token: write, and a job with no condition runs on " +
+      "every event ci.yml accepts, which includes every push to main and every " +
+      "pull_request. Restore the condition, and record any operand beyond the release " +
+      "definition in PUBLISH_CONDITIONS_BEYOND_RELEASE in this file.",
+  );
+}
+if (releaseJob && releaseIf === null) {
+  problems.push(
+    "jobs.release has no `if:` condition, so it would attempt a GitHub Release on " +
+      "every event ci.yml accepts. It is also the job the publish condition is held " +
+      "against, so with no condition there is nothing to hold it to.",
+  );
+}
+
+const releaseCondition = releaseIf === null ? null : normaliseCondition(releaseIf);
+const publishOperands = publishIf === null ? null : splitTopLevelOr(publishIf);
+const beyondRelease = (publishOperands ?? []).filter((o) => o !== RELEASE_REF_CONDITION);
+const releaseOperandCount = (publishOperands ?? []).filter((o) => o === RELEASE_REF_CONDITION).length;
+const unrecorded = beyondRelease.filter((o) => !PUBLISH_CONDITIONS_BEYOND_RELEASE.includes(o));
+const recordedButGone = PUBLISH_CONDITIONS_BEYOND_RELEASE.filter((o) => !beyondRelease.includes(o));
+
+// The guards. Each is deliberately ONE line: the mutation tests in
+// tests/runtime-support.bats delete one of them at a time, and deleting any single
+// guard must turn exactly one of those tests red while the rest stay green. A guard
+// that cannot be removed in isolation cannot be proved to be doing anything.
+if (releaseIf !== null && releaseCondition !== RELEASE_REF_CONDITION) problems.push(releaseDefinitionMessage(releaseCondition));
+if (publishIf !== null && publishOperands === null) problems.push(UNREADABLE_PUBLISH_CONDITION);
+if (publishOperands !== null && releaseOperandCount !== 1) problems.push(publishShapeMessage(releaseOperandCount, publishOperands));
+for (const operand of publishOperands === null ? [] : unrecorded) problems.push(unrecordedOperandMessage(operand));
+for (const operand of publishOperands === null ? [] : recordedButGone) problems.push(recordedOperandGoneMessage(operand));
 
 if (problems.length > 0) {
   for (const p of problems) console.error(`  - ${p}`);

--- a/tests/runtime-support.bats
+++ b/tests/runtime-support.bats
@@ -303,3 +303,137 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"repo CI shape OK"* ]]
 }
+
+# ─── Release authorization: one definition of a release, nothing beyond it that
+# ─── is not recorded (https://github.com/homeofe/AAHP/issues/69) ──────────────
+#
+# The third assertion in tests/assert-repo-ci-shape.mjs is the only thing in this
+# repository that reads either release-critical job condition. It is worth exactly
+# as much as its ability to go red, so every test below mutates ONE line of a copy
+# of the REAL ci.yml and asserts the exact exit code. The control test proves the
+# untouched copy is green, so a red result can only be caused by the mutation.
+
+# Copy the real repository shape (package.json and ci.yml) into TEST_TMPDIR. The
+# assertion takes a root as argv[1], so it runs against the copy without the
+# mutations ever touching the working tree.
+copy_repo_shape() {
+    mkdir -p "$(wf_dir)"
+    cp "$AAHP_ROOT/package.json" "$TEST_TMPDIR/package.json"
+    cp "$AAHP_ROOT/.github/workflows/ci.yml" "$(wf_dir)/ci.yml"
+}
+
+# Replace the `if:` line of job $1 in the fixture ci.yml with $2; an empty $2
+# deletes the line. awk rather than `sed -i` on purpose: these conditions contain
+# `&&`, and a bare `&` in a sed replacement means "the whole match", so the sed
+# form would silently write something other than what the test says it writes.
+# Exits non-zero when the job has no `if:` line, so a mutation that quietly
+# applied to nothing cannot pass as a green test. The job header is compared with
+# any trailing CR removed: ci.yml is not covered by .gitattributes, so a Windows
+# checkout has CRLF endings and a byte comparison would silently match nothing.
+set_job_if() {
+    local job="$1" repl="$2" file
+    file="$(wf_dir)/ci.yml"
+    awk -v job="$job" -v repl="$repl" '
+        /^  [A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/ {
+            hdr = $0
+            sub(/\r$/, "", hdr)
+            injob = (hdr == "  " job ":")
+        }
+        {
+            if (injob && !done && $0 ~ /^    if:/) {
+                done = 1
+                if (repl != "") print repl
+                next
+            }
+            print
+        }
+        END { if (!done) exit 3 }
+    ' "$file" > "$file.new" || { rm -f "$file.new"; return 3; }
+    mv "$file.new" "$file"
+}
+
+@test "release authorization: the untouched repository shape is green" {
+    copy_repo_shape
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"repo CI shape OK"* ]]
+}
+
+@test "release authorization: a publish job with no if: at all is red" {
+    # The mutation that a test matching an expected string would sail past. A
+    # publish job with no condition runs on every event ci.yml accepts, which is
+    # strictly worse than any condition it could carry.
+    copy_repo_shape
+    set_job_if publish ""
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"jobs.publish has no \`if:\` condition"* ]]
+}
+
+@test "release authorization: changing only the release job's condition is red" {
+    # The two jobs must share ONE definition of a release. Moving one of them is
+    # the drift this assertion exists to catch, so it has to be red even though
+    # the publish condition is untouched and still matches its record.
+    copy_repo_shape
+    set_job_if release "    if: startsWith(github.ref, 'refs/tags/')"
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"jobs.release.if is not the recorded release definition"* ]]
+}
+
+@test "release authorization: an unrecorded operand on the publish condition is red" {
+    copy_repo_shape
+    set_job_if publish "    if: (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')) || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'"
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"has not recorded: github.ref == 'refs/heads/main'"* ]]
+}
+
+@test "release authorization: removing a recorded operand is red until the record is updated" {
+    # Tightening the condition is not a defect, but leaving the record claiming a
+    # permission the workflow no longer grants is. Adopting that option is a
+    # two-line edit the failure message names.
+    copy_repo_shape
+    set_job_if publish "    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')"
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no longer carries a recorded condition: github.event_name == 'workflow_dispatch'"* ]]
+}
+
+@test "release authorization: an AND-shaped publish condition is red, not silently accepted" {
+    # Requiring a tag ref on the dispatch path too is one of the options open in
+    # ADR-019. It is a policy change, so it must be recorded rather than absorbed.
+    copy_repo_shape
+    set_job_if publish "    if: (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not carry the shared release definition exactly once"* ]]
+}
+
+@test "release authorization: reformatting the condition does not change the verdict" {
+    # Proves the assertion reads the PARSED condition rather than a substring of
+    # the file: redundant parentheses and extra spaces are the same expression, so
+    # they must stay green, or the gate would be a formatting rule wearing a
+    # security rule's clothes.
+    copy_repo_shape
+    set_job_if publish "    if: ((  startsWith(github.ref, 'refs/tags/v')   &&   contains(github.ref, '.')  ))   ||   github.event_name == 'workflow_dispatch'"
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"repo CI shape OK"* ]]
+}
+
+@test "release authorization: a publish condition that cannot be read is red, never a skip" {
+    copy_repo_shape
+    set_job_if publish "    if: \"(startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.') || github.event_name == 'workflow_dispatch'\""
+
+    run node "$AAHP_ROOT/tests/assert-repo-ci-shape.mjs" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"jobs.publish.if could not be read"* ]]
+}


### PR DESCRIPTION
Addresses https://github.com/homeofe/AAHP/issues/69, for the half of it that is not a policy question. It deliberately does **not** decide whether a manual publish path should exist. No closing keyword: that decision is one of the issue's acceptance criteria and only the owner can take it.

## What was wrong

`.github/workflows/ci.yml` has two release-critical jobs. `publish` runs `npm publish --access public --provenance` with `id-token: write`. `release` creates the GitHub Release for the same ref. Each carried its own hand-written `if:`, and the two answered "is this a release?" differently: `publish` additionally accepted `github.event_name == 'workflow_dispatch'`, an operand that constrains no ref at all.

The disagreement is not the part that mattered most. **Nothing in this repository read either condition.** `scripts/check-verify-workflow.mjs` is 587 lines devoted to whether a workflow `if:` lets a required gate SKIP; the inverse question for the publish job, whether an `if:` lets a publish RUN on an event that is not a release, was asked by nothing. `tests/assert-repo-ci-shape.mjs`, the existing CI-shape gate, never read any job's `if:` at all, and `aahp doctor` passed seven gates clean without looking. So the drift was invisible, and any future edit to publish authorization would have been equally silent.

## What changed

**No workflow behaviour changes.** The publish condition is byte-identical to what it was: the same events publish and the same events do not.

1. `tests/assert-repo-ci-shape.mjs` gains a third assertion. The release definition `startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')` is now written ONCE, as `RELEASE_REF_CONDITION`. Both jobs must use exactly it, and every additional top-level `||` operand on the publish condition must appear in `PUBLISH_CONDITIONS_BEYOND_RELEASE` in the same file. It reads the PARSED condition from the YAML rather than a substring of the file, so reformatting the workflow changes no verdict. A job with no `if:` at all is a failure rather than a pass, because a job with no condition runs on every event the workflow accepts.
2. `.github/workflows/ci.yml` gains a comment above each of the two conditions: which operand is the shared release definition, which one is a separate standing permission, and that the second is an open owner decision.
3. `README.md` gains **ADR-019**, recording the decision that was taken (one release definition, machine-asserted) and the one that was not (whether the `workflow_dispatch` operand should exist at all), with options A, B and C and what each one requires.

Enforcement path, verified rather than assumed: `tests/runtime-support.bats` runs the assertion, `npm test` runs that file, the `npm test` step runs inside `lint-and-validate`, and `lint-and-validate` is a required status check on `main`. A change to publish authorization that is not also recorded cannot merge.

## Assumptions and decisions, recorded in the repository

Everything below lives in the repository, not in this description.

- The release definition and the recorded operand list are constants in `tests/assert-repo-ci-shape.mjs`, each with its reason written next to it.
- The measurement the recorded list rests on is dated in the file and in ADR-019, and was taken independently for this change rather than carried over: none of this workflow's 147 runs, measured 2026-08-22, was a manual dispatch (`gh run list -R homeofe/AAHP -w ci.yml -L 400 --json event`, grouped: 77 `push`, 70 `pull_request`, 0 `workflow_dispatch`).
- The open owner decision, and what each of options A, B and C requires, is in ADR-019 in `README.md`, in the comment above the condition in `ci.yml`, and as a row in `.ai/handoff/STATUS.md`.
- Option B's caveat is recorded with it: this repository's one existing environment has an empty `protection_rules` list, so naming an `environment:` with no required reviewer would add a label and no control.
- The exit contract (`0` when every assertion holds, `1` when at least one does not, no third code and no skip) is in the file header, with the reason an unreadable condition is a failure rather than a skip.
- The expression reader's one assumption about GitHub Actions syntax, that literals are single-quoted and a quote is escaped by doubling it, is written in the docstring of the function that relies on it.

**This change introduces no bound.** There is no threshold, timeout, limit, or tolerance in it. The recorded operand list is literal, has no pattern and no wildcard entry, and an empty list is a meaningful state rather than "unchecked".

## Verification

### The finding no longer reproduces

The reproduction's absence probe was that nothing reads a job condition. Counting lines in the CI-shape gate that reference `jobs.publish` or `jobs.release`:

```
$ grep -cE 'jobs\??\.\[?["'"'"']?(publish|release)' <file>
origin/main : 0
this branch : 10
```

Positive control on the same pipeline, a term present in both versions of that file:

```
$ grep -c 'runtime-matrix' <file>
origin/main : 3
this branch : 3
```

So the zero is a real absence, not a broken pipeline.

Two of the reproduction's static probes still match, and that is correct rather than a gap:

- `awk '/^  publish:/,/^  release:/' .github/workflows/ci.yml | grep -c 'environment:'` is still `0`. Adding an `environment:` is option B, a policy choice this pull request does not take.
- The publish condition itself still contains the dispatch operand, because the condition is unchanged by design.

What changed is that the condition is now read by something that can fail. That cannot be shown by a static probe on the workflow, so it is settled by execution below.

### The regression test, and the mutation that reddens it

`tests/runtime-support.bats` gains eight tests. Each copies the REAL `package.json` and `ci.yml` into a temporary root, changes at most ONE line of the workflow, and asserts the EXACT exit code, never merely non-zero. The control test proves the untouched copy is green, so a red result can only be caused by the mutation.

| test | mutation | expected |
| --- | --- | --- |
| the untouched repository shape is green | none | exit 0 |
| a publish job with no `if:` at all is red | delete `jobs.publish.if` | exit 1 |
| changing only the release job's condition is red | edit `jobs.release.if` only | exit 1 |
| an unrecorded operand is red | add `\|\| github.ref == 'refs/heads/main'` | exit 1 |
| removing a recorded operand is red until the record is updated | delete the dispatch operand | exit 1 |
| an AND-shaped publish condition is red | option B's shape | exit 1 |
| reformatting the condition does not change the verdict | redundant parentheses and spaces | exit 0 |
| a publish condition that cannot be read is red, never a skip | unbalanced parentheses | exit 1 |

The second row is the one that matters most: a test that merely matched an expected string would sail past a publish job with no condition at all, which is strictly worse than the condition being fixed.

#### The line a reviewer deletes to redden it

`tests/assert-repo-ci-shape.mjs`:

```js
for (const operand of publishOperands === null ? [] : unrecorded) problems.push(unrecordedOperandMessage(operand));
```

The five guards in that file are each written on one line for exactly this reason: any one of them can be removed on its own, so each can be shown to be doing something.

Deleted, then the file re-read from disk to prove the mutation landed. Sequenced with `;` rather than `&&`, so no step's exit code can stand in for another's:

```
$ python3 <delete that one line> ; grep -c 'unrecorded) problems.push' tests/assert-repo-ci-shape.mjs ; grep -cE '^(if \(releaseIf|if \(publishIf|if \(publishOperands|for \(const operand)' tests/assert-repo-ci-shape.mjs ; grep -c 'publishShapeMessage(releaseOperandCount, publishOperands))' tests/assert-repo-ci-shape.mjs ; node --check tests/assert-repo-ci-shape.mjs ; echo "node --check exit=$?"
delete done
0        <- the deleted guard is gone
4        <- guards at file scope, down from 5
1        <- the neighbouring guard is untouched, so the deletion is the intended one
node --check exit=0     <- still valid syntax, so any red is logic and not a parse error
```

Then the test:

```
$ npx bats -f "unrecorded operand" tests/runtime-support.bats
1..1
not ok 1 release authorization: an unrecorded operand on the publish condition is red
# (in test file tests/runtime-support.bats, line 392)
#   `[ "$status" -eq 1 ]' failed
EXIT=1
```

It failed on the exit-code assertion itself: with that guard gone, a publish condition carrying an unrecorded operand made the gate exit `0` where the test requires exactly `1`. That is the defect coming back, and the test catches it.

Restored, and the gate is green again:

```
$ python3 <restore that one line> ; grep -c 'unrecorded) problems.push' tests/assert-repo-ci-shape.mjs ; node tests/assert-repo-ci-shape.mjs . ; echo "gate exit=$?"
restore done
1
repo CI shape OK
gate exit=0
```

#### All eight, on the tree as committed

```
$ npx bats -f "release authorization" tests/runtime-support.bats
1..8
ok 1 release authorization: the untouched repository shape is green
ok 2 release authorization: a publish job with no if: at all is red
ok 3 release authorization: changing only the release job's condition is red
ok 4 release authorization: an unrecorded operand on the publish condition is red
ok 5 release authorization: removing a recorded operand is red until the record is updated
ok 6 release authorization: an AND-shaped publish condition is red, not silently accepted
ok 7 release authorization: reformatting the condition does not change the verdict
      0 [main] bash 66035 dofork: child -1 - forked process 39496 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
tracing.bash: fork: retry: Resource temporarily unavailable
ok 8 release authorization: a publish condition that cannot be read is red, never a skip
```

Reported exactly as it came out. The two lines before `ok 8` are a Git Bash fork failure on a loaded Windows workstation, which Bats retried through; the test then reported `ok`. The wrapper's own exit code is not shown because the wrapper process was terminated once the last test had reported, so it is not claimed here. Every one of the eight tests reported `ok` against a satisfied `1..8` plan, and the full-suite verdict is Linux CI's, per this repository's own note that a Windows local run is not authoritative.

### The other gates still pass

```
$ node bin/aahp.js doctor .
Conformance OK: 7 gate(s), no failures.

$ npm run check
Changelog presence OK / Changelog format OK / Version sync OK / Forbidden patterns OK /
Schema-doc sync OK / Doc links OK / Runtime support OK / Handoff generator OK

$ node tests/assert-workflow-parser-parity.mjs .
workflow parser parity OK (16 workflow file(s))

$ bash scripts/verify-handoff.sh . --level precommit
[Layer 1] MANIFEST integrity: indexed files present and unchanged
  OK: Checksums and handoff lint pass.
[Layer 2] Content-drift gate (code changed => handoff must change)
  OK
aahp verify passed (level: precommit).
EXIT=0
```

One note on how `.ai/handoff/MANIFEST.json` was updated, because it was not updated the usual way. `scripts/aahp-manifest.sh` could not complete on this machine: Git Bash ran out of forks under load and the run exited 255 without writing anything, leaving the file untouched rather than half written. The index entry was therefore recomputed with the generator's own arithmetic, applied surgically so every untouched field stays byte identical: `sha256` of the file with every CR removed, `wc -l` for lines, and `(wc -w * 13 + 9) / 10` per file for the token budget, exactly as `scripts/_aahp-lib.sh` and `scripts/aahp-manifest.sh` define them. The result was then checked rather than trusted: `aahp_checksum` and `aahp_line_count` from the repository's own library reproduce the written checksum and line count exactly, the token budget was recomputed a second time by an independent implementation and matched, and Layer 1 above confirms the whole index end to end.

The full Bats suite was not run on Windows, only the file covering this change. Linux CI is the authoritative full-suite verdict, as the repository's own notes require.

## What this pull request does not do

- It does not remove, constrain, or otherwise change the `workflow_dispatch` operand. That is the owner's call, and ADR-019 is where it is recorded.
- It does not add an `environment:` to the publish job (option B).
- It does not touch the unpinned third-party CLI in `lint-and-validate`, tracked separately at https://github.com/homeofe/AAHP/issues/68.
- It does not change the issue's labels. The reproduction assessed the security framing as overstated (no external reachability, and the one principal who can dispatch is the one who can already push a release tag) and the release-integrity framing as the accurate one. Whether `priority: high` should move is the owner's call, recorded here rather than acted on.
