### PR TITLE
chore(git): STATUS.md is an append-log, so declare merge=union

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -11,9 +11,9 @@
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:0bb2cfad095d6bc987b3821f0a10f23c876bcaf93af6da0fdf9229808e8a632b",
+      "checksum": "sha256:d35aa54e0d175c52e6d90eb32cb660328cfc7c5b2d48ae7093ad06585e2097a1",
       "updated": "2026-08-22T21:32:06Z",
-      "lines": 131,
+      "lines": 145,
       "summary": "AAHP **v3.10.0** (npm `@elvatis_com/aahp`) is prepared on a review branch. It has not"
     },
     "NEXT_ACTIONS.md": {
@@ -82,7 +82,60 @@
     "manifest_only": 85,
     "manifest_plus_core": 4922,
     "full_read": 14992
+  },
+  "next_task_id": 18,
+  "tasks": {
+    "T-006": {
+      "title": "Publish npm package",
+      "status": "done",
+      "priority": "medium",
+      "depends_on": [],
+      "created": "2026-06-28T10:10:21.975Z",
+      "notes": "**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*",
+      "github_issue": 18,
+      "github_repo": "homeofe/AAHP",
+      "completed": "2026-07-14T00:00:00Z"
+    },
+    "T-014": {
+      "title": "Add CLI integration tests for bin/aahp.js [high]",
+      "status": "done",
+      "priority": "high",
+      "depends_on": [],
+      "created": "2026-06-28T10:10:21.975Z",
+      "notes": "**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*",
+      "github_issue": 14,
+      "github_repo": "homeofe/AAHP",
+      "completed": "2026-07-14T00:00:00Z"
+    },
+    "T-015": {
+      "title": "Add `aahp status` quick-look command [medium]",
+      "status": "done",
+      "priority": "medium",
+      "depends_on": [],
+      "created": "2026-06-28T10:10:21.978Z",
+      "github_issue": 22,
+      "github_repo": "homeofe/AAHP",
+      "completed": "2026-07-14T00:00:00Z"
+    },
+    "T-016": {
+      "title": "Add `aahp archive` command for LOG.md rotation [medium]",
+      "status": "done",
+      "priority": "medium",
+      "depends_on": [],
+      "created": "2026-06-28T10:10:21.979Z",
+      "github_issue": 23,
+      "github_repo": "homeofe/AAHP",
+      "completed": "2026-07-14T00:00:00Z"
+    },
+    "T-017": {
+      "title": "Add project-level CLAUDE.md [low]",
+      "status": "done",
+      "priority": "low",
+      "depends_on": [],
+      "created": "2026-06-28T10:10:21.979Z",
+      "github_issue": 24,
+      "github_repo": "homeofe/AAHP",
+      "completed": "2026-07-14T00:00:00Z"
+    }
   }
-  ,"next_task_id": 18
-  ,"tasks": {"T-006":{"title":"Publish npm package","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-006`  \n**Status:** blocked  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":18,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-014":{"title":"Add CLI integration tests for bin/aahp.js [high]","status":"done","priority":"high","depends_on":[],"created":"2026-06-28T10:10:21.975Z","notes":"**AAHP Task:** `T-014`  \n**Status:** ready  \n**Priority:** high  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: AAHP*","github_issue":14,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-015":{"title":"Add `aahp status` quick-look command [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.978Z","github_issue":22,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-016":{"title":"Add `aahp archive` command for LOG.md rotation [medium]","status":"done","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":23,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"},"T-017":{"title":"Add project-level CLAUDE.md [low]","status":"done","priority":"low","depends_on":[],"created":"2026-06-28T10:10:21.979Z","github_issue":24,"github_repo":"homeofe/AAHP","completed":"2026-07-14T00:00:00Z"}}
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,17 @@
+## 2026-08-23 - declare merge=union for the handoff append-log
+
+`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by
+one block and nothing else. Eight sibling repositories in this estate already
+declare `merge=union` for it; this one did not, and the two that lacked it are
+exactly the two where twenty-two rebases on 2026-08-23 each resolved this file by
+hand.
+
+It does not stop a pull request going CONFLICTING - GitHub does not honour merge
+drivers server-side, measured 2026-07-31 - so this removes the hand resolution,
+not the merge. `MANIFEST.json` is deliberately left without a driver: it is
+generated state, and the correct resolution is to take main's copy and recompute
+the changed entries, which no driver can do.
+
 # AAHP: Current State of the Nation
 
 > Last updated: 2026-08-22 by claude (verify-workflow gate: can the workflow that runs the gate skip it?)

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,17 @@
 *.sh text eol=lf
 *.bash text eol=lf
 *.bats text eol=lf
+
+# `.ai/handoff/STATUS.md` is an append-log: every pull request prepends its own
+# session note, so two branches almost always differ by one prepended block and
+# nothing else. `union` keeps both sides, which is the correct resolution here
+# and the only one that does not lose somebody's note.
+#
+# Verified for local `git merge`. GitHub does NOT honour merge drivers
+# server-side (measured 2026-07-31 in Shield: two PRs touching STATUS.md still
+# showed as CONFLICTING after a third merged), so a PR touching STATUS.md still
+# needs a local merge before it can land. What this removes is the HAND
+# resolution, not the merge itself. Measured here on 2026-08-23: twenty-two
+# rebases in one session, every one of them resolving this file by hand, in the
+# two repositories that lacked this line while eight siblings had it.
+.ai/handoff/STATUS.md merge=union


### PR DESCRIPTION
`.ai/handoff/STATUS.md` is prepend-only: every pull request adds its own session note at the top, so two branches differ by one block and nothing else. `union` keeps both sides, which is the correct resolution and the only one that cannot lose a note.

**Eight sibling repositories in this estate already carry this line.** This one did not, and the two that lacked it are exactly the two where twenty-two rebases on 2026-08-23 each resolved this file by hand.

**What this does not do**, stated because the sibling repositories' own comment measured it and it would otherwise be over-claimed: GitHub does not honour merge drivers server-side (measured 2026-07-31 in Shield - two pull requests touching STATUS.md still showed CONFLICTING after a third merged). A pull request touching STATUS.md will still go dirty and still needs a local merge before it can land. **This removes the hand resolution, not the merge.**

`.ai/handoff/MANIFEST.json` is deliberately NOT given a driver: it is generated state, so the correct resolution is to take main's copy and recompute the changed entries, which no driver can do.

## Acceptance criteria

- [x] The line matches the wording the eight sibling repositories use
- [x] The comment states what it does not fix, with the date that was measured
- [x] MANIFEST.json is left without a driver, and the reason is written down
- [ ] CI green for this head, which is a merge precondition rather than a checkbox