### PR TITLE
fix(gates): the workflow we ship to consumers pinned a Node the package disclaims

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,85 +3,85 @@
   "project": "AAHP",
   "last_session": {
     "agent": "cli-tool",
-    "session_id": "cli-1787445019",
-    "timestamp": "2026-08-23T00:30:20Z",
-    "commit": "608a840",
-    "phase": "idle",
+    "session_id": "cli-1787475552",
+    "timestamp": "2026-08-23T08:59:14Z",
+    "commit": "b67b3cc",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:5cca61412e033827a9be88486d473f90ac21ab826083ee409feecf9359c2cfb0",
-      "updated": "2026-08-23T00:30:12Z",
-      "lines": 217,
-      "summary": "`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by"
+      "checksum": "sha256:730dc44bcb895fc2d01411cbc7e1e74471c9db55d776205ed5007410d85dfe7f",
+      "updated": "2026-08-23T08:57:15Z",
+      "lines": 259,
+      "summary": "`assets/governance/aahp-govern.yml` - the workflow `aahp init --gates` scaffolds"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:efdc6ef8664faf9ce5120fa797b702d2353bd4c3205c62e5ba651a465326103d",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 239,
       "summary": "Current version: **v3.10.0**"
     },
     "LOG.md": {
       "checksum": "sha256:b6296369cedefd0c52a00e8ed2662ad839e238e8162d93c0fda76547e30c0bce",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 250,
       "summary": "**Agent:** claude-opus-5"
     },
     "LOG-ARCHIVE.md": {
       "checksum": "sha256:952cebfc3ba42ba60c913defd9ca292d122a4151230b53e59b9201fd0dac5933",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 159,
       "summary": "**Agent:** Claude Opus 4.6"
     },
     "LOG-ARCHIVE.index.json": {
       "checksum": "sha256:5cb8447453139052e528f8dfc67d88f3d5e74bb40e5fc1672aa55ca30980de98",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 29,
       "summary": "{"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:e96e392db8dab2e9719e542dfa2a10c240d0be16ac6721298c460a22985cbdea",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 96,
       "summary": "| Name | Path | Build | Tests | Status | Notes |"
     },
     "TRUST.md": {
       "checksum": "sha256:91f124fe10a934779ef1d7442dd54af6656bbc03c4b1cde13a9d4cac9ab248e6",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 93,
       "summary": "| Level | Meaning |"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:1c0150404d22c6e15e39139e8b2c991b0167ba1e095f579efafb85555dfe0d88",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 93,
       "summary": "The project motto (Asimov's Three Laws) and the **do no damage** principle live once, in README (## Our Motto: The Three Laws). Agents must never take"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:ef005f24e399791abb986b3a76403295c33ad3b28bb9b7dc777d1d0528b31151",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 156,
       "summary": "| Agent | Model | Role | Responsibility |"
     },
     "GROUNDING.md": {
       "checksum": "sha256:7ef8cece585dc5defb4285175b9ba560d5469675df553d4ce28ec9e7aec24343",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 209,
       "summary": "This register EXTENDS existing AAHP machinery; it does not fork or replace it. It"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-08-23T00:12:58Z",
+      "updated": "2026-08-23T08:32:44Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "`.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by Current version: **v3.10.0** ",
+  "quick_context": "`assets/governance/aahp-govern.yml` - the workflow `aahp init --gates` scaffolds Current version: **v3.10.0** ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 8300,
-    "full_read": 18370
+    "manifest_plus_core": 9109,
+    "full_read": 19179
   },
   "next_task_id": 18,
   "tasks": {

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,45 @@
+## 2026-08-23 - the shipped governance workflow pinned Node 20 against a >=22 floor
+
+`assets/governance/aahp-govern.yml` - the workflow `aahp init --gates` scaffolds
+into a consumer repository - pinned `node-version: '20'` while `package.json`
+declared `engines.node: ">=22"`. Every repository that scaffolded it installed and
+ran the AAHP CLI below the CLI's own engine floor, on a runtime end-of-life since
+2026-04-30. It was silent at both ends: npm answers an unmet `engines` range with
+an `EBADENGINE` warning and exits 0, so the adopter's gate stayed green while
+running unsupported.
+
+The interesting half is why it lasted. `scripts/check-runtime-support.mjs` exists
+to assert exactly this relation, and its own header names the file this package
+propagates as the reason it was written - but it scanned `.github/workflows/`
+only. AAHP propagates by TWO routes: `propagate.sh` copies `aahp-verify.yml`, and
+`aahp init --gates` copies `aahp-govern.yml`. The gate covered the first and was
+green on every commit while the second violated it. Its two sibling gates,
+`tests/assert-workflow-hardening.mjs` and `scripts/check-workflow-pinning.mjs`,
+already scanned both directories; the runtime gate was the odd one out.
+
+So the pin is corrected AND the gate now reads `assets/governance/` too, with the
+shipped root excluded from the release-vs-build membership check - a job that never
+runs here must not vouch for a release runtime nothing proved. Widening a gate's
+scope must not let it assert less.
+
+The scan root is OPTIONAL rather than required, unlike its sibling in
+`assert-workflow-hardening.mjs`, because this gate also runs against fixture roots
+that legitimately ship no template. That leaves a hole - dropping the root would be
+silent - and it is closed from the other side: the gate's summary names every file
+it scanned, and `tests/runtime-support.bats` asserts the real tree's shipped
+template appears in it. Coverage is proved by observation, not assumed from a flag.
+
+Verified locally: `tests/runtime-support.bats` 30/30, `tests/init-gates.bats` and
+`tests/workflow-hardening.bats` green, `npm run check` green (10 gates). Mutation
+proof both ways - narrowing the gate back to one directory turns the two new
+coverage tests red; removing the shipped exclusion turns the membership test red.
+Per repository policy the full Bats suite is left to Linux CI, not run on Windows.
+
+Not touched: the template still uses `actions/checkout@v4` and
+`actions/setup-node@v4` by tag while this repository's own workflows pin action
+SHAs. That is a separate decision about what adopters should read, and
+`check-workflow-pinning.mjs` currently passes it, so it is recorded here rather
+than changed in a pin fix.
 ## 2026-08-23 - declare merge=union for the handoff append-log
 
 `.ai/handoff/STATUS.md` is prepend-only, so two branches almost always differ by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,28 @@ independently of the npm version).
   scalars, and would report a clean repository it never actually read.
 
 ### Fixed
+- The governance workflow `aahp init --gates` scaffolds into a consumer repository
+  (`assets/governance/aahp-govern.yml`) no longer pins Node 20 - a runtime end-of-life since
+  2026-04-30, and below the `engines.node: ">=22"` floor the package publishes. Every
+  repository that scaffolded it ran `npm ci --ignore-scripts` and then the AAHP CLI under
+  the CLI's own engine floor. Nothing reported it at either end: npm answers an unmet
+  `engines` range with an `EBADENGINE` warning and continues, so the adopter's gate stayed
+  green while running unsupported. `.github/workflows/aahp-verify.yml` - the file that
+  reaches consumers by the other route, `propagate.sh` - has pinned 22 with a comment
+  naming the reason since the floor moved; the scaffolded file was never brought along.
+- `npm run check:runtime-support` now reads `assets/governance/` as well as
+  `.github/workflows/`, which is why the pin above could sit wrong indefinitely. That
+  gate exists precisely to assert "no runtime pin is below the published floor", its
+  header names the file this package propagates as the reason it exists, and it was
+  green on every commit while the shipped template violated it - because AAHP
+  propagates by TWO routes and the gate read only the directory covered by one of
+  them. Its two sibling gates, `tests/assert-workflow-hardening.mjs` and
+  `scripts/check-workflow-pinning.mjs`, already scanned both; this was the odd one out.
+  A pin in the shipped template is reported with what actually goes wrong there (an
+  adopter's CI running the published CLI below its engine floor) rather than the
+  local wording, and it is excluded from the release-vs-build membership check: a job
+  that never executes here must not vouch for a release runtime nothing proved.
+  Widening a gate's scope must not let it assert less.
 - `MANIFEST.json`'s `project` no longer takes the name of the directory the generator
   ran in. It resolves the repository's identity instead: the name already on record in
   `MANIFEST.json` first, then the git remote's repository name, and the directory

--- a/assets/governance/aahp-govern.yml
+++ b/assets/governance/aahp-govern.yml
@@ -62,7 +62,14 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 22 is the floor engines.node publishes for @elvatis_com/aahp.
+          # `aahp init --gates` copies this file into a consumer repository
+          # byte-identical, so this pin is the runtime every adopting repo runs
+          # the gates on. A lower pin does not fail loudly: `npm ci` emits
+          # EBADENGINE and carries on, so the CLI then runs on a runtime the
+          # package does not claim to support. scripts/check-runtime-support.mjs
+          # scans this directory for exactly that reason - see its SCAN_ROOTS.
+          node-version: '22'
       - name: Install pinned aahp devDependency
         run: npm ci --ignore-scripts
       - name: Run governance gates

--- a/scripts/check-runtime-support.mjs
+++ b/scripts/check-runtime-support.mjs
@@ -154,23 +154,99 @@ function enginesFloor() {
 
 // ---------------------------------------------------------------------------
 // Every Node major any workflow asks for, and where it came from.
+//
+// SCOPE, and why it is two directories and not one
+//
+//   .github/workflows/  - what this repository RUNS. A pin below the floor
+//                         here means CI proves the package on a runtime the
+//                         package does not claim to support.
+//   assets/governance/  - what this repository SHIPS. `aahp init --gates`
+//                         copies aahp-govern.yml from here into a consumer
+//                         repository and `npm pack` puts it in the published
+//                         tarball, so a pin below the floor here is a support
+//                         claim that breaks on install, in repositories this
+//                         gate will never run in.
+//
+// Measured 2026-08-23: the shipped template pinned Node 20 while engines.node
+// said '>=22', and had done so while this gate ran green on every commit -
+// because the gate read one directory and the defect sat in the other. The
+// header above blames this exact class of defect on the file the package
+// propagates, and then scanned only the copy that propagates via propagate.sh.
+// The consumer-facing copy travels a second route (`aahp init --gates`) that
+// nothing here was looking at.
+//
+// Two sibling gates already hold the shipped template to the same bar as the
+// local workflows - tests/assert-workflow-hardening.mjs (SCAN_ROOTS) and
+// scripts/check-workflow-pinning.mjs (TEMPLATE_DIRS). This list is the third,
+// and the divergence is the reason to keep all three named together: a new
+// gate over workflows is wrong by default until it states which route it
+// covers.
+//
+// WHAT AN ABSENT ROOT MEANS, and why the two answers differ
+//
+// For .github/workflows absence is exit 2. This gate asserts a relation
+// between runtime pins and a support claim; with no workflows the relation is
+// UNTESTED, not satisfied, and "I could not look" must never read as "I looked
+// and it was fine".
+//
+// For assets/governance absence is not a finding at all, because the gate also
+// runs against roots that legitimately ship nothing - every fixture in
+// tests/runtime-support.bats is such a root, and so is any consumer project if
+// this gate ever becomes portable. A package that ships no template has no
+// template to get wrong.
+//
+// That asymmetry is a real hole: silently dropping the root by renaming or
+// deleting the directory would return this gate to the blindness described
+// above, and nothing would go red. It is closed on the OTHER side - the summary
+// below names every file actually scanned, and tests/runtime-support.bats
+// asserts that the real repository's shipped template appears in it. Coverage
+// is therefore proved by observation of the real tree, not assumed from a flag.
 // ---------------------------------------------------------------------------
-const workflowsDir = join(root, ".github", "workflows");
+const SCAN_ROOTS = [
+  {
+    dir: [".github", "workflows"],
+    label: ".github/workflows",
+    why: "what this repository runs",
+    required: true,
+    shipped: false,
+  },
+  {
+    dir: ["assets", "governance"],
+    label: "assets/governance",
+    why: "the workflow template `aahp init --gates` copies into consumer repositories",
+    required: false,
+    shipped: true,
+  },
+];
 
+// Returns { dir, file, label } for every YAML file under every scan root.
+// `label` is what findings name, so a message reads
+// `assets/governance/aahp-govern.yml:govern` rather than a bare filename - two
+// roots can hold files of the same name, and the route a file travels is the
+// whole point of scanning it.
 function workflowFiles() {
-  if (!existsSync(workflowsDir)) {
-    bail(2, [
-      `Runtime support: no workflow directory at ${workflowsDir}.`,
-      "This gate asserts a relation between CI pins and the published support",
-      "claim. With no workflows there are no pins, so the relation is untested",
-      "rather than satisfied.",
-    ]);
+  const found = [];
+  for (const scan of SCAN_ROOTS) {
+    const dir = join(root, ...scan.dir);
+    if (!existsSync(dir)) {
+      if (!scan.required) continue;
+      bail(2, [
+        `Runtime support: no workflow directory at ${dir}.`,
+        "This gate asserts a relation between CI pins and the published support",
+        "claim. With no workflows there are no pins, so the relation is untested",
+        "rather than satisfied.",
+      ]);
+    }
+    const files = readdirSync(dir).filter((f) => /\.ya?ml$/.test(f)).sort();
+    if (files.length === 0) {
+      if (!scan.required) continue;
+      bail(2, [`Runtime support: ${dir} contains no workflow files.`]);
+    }
+    for (const file of files) {
+      found.push({ dir, file, label: `${scan.label}/${file}`, shipped: scan.shipped });
+    }
   }
-  const files = readdirSync(workflowsDir).filter((f) => /\.ya?ml$/.test(f)).sort();
-  if (files.length === 0) {
-    bail(2, [`Runtime support: ${workflowsDir} contains no workflow files.`]);
-  }
-  return files;
+  return found;
 }
 
 function majorOf(value, where) {
@@ -184,13 +260,13 @@ function majorOf(value, where) {
   return Number(m[1]);
 }
 
-function parseWorkflow(file) {
-  const text = readFileSync(join(workflowsDir, file), "utf8");
+function parseWorkflow({ dir, file, label }) {
+  const text = readFileSync(join(dir, file), "utf8");
   try {
     return YAML.parse(text) ?? {};
   } catch (err) {
     bail(2, [
-      `Runtime support: ${file} is not valid YAML (${err.message}).`,
+      `Runtime support: ${label} is not valid YAML (${err.message}).`,
       "The gate refuses to guess at a file it cannot parse.",
     ]);
   }
@@ -245,17 +321,17 @@ function stepMajors(job, where) {
 const pins = [];
 const allMatrixMajors = [];
 
-for (const file of workflowFiles()) {
-  const doc = parseWorkflow(file);
+for (const entry of workflowFiles()) {
+  const doc = parseWorkflow(entry);
   const jobs = doc?.jobs;
   if (!jobs || typeof jobs !== "object") continue;
   for (const [jobName, job] of Object.entries(jobs)) {
-    const where = `${file}:${jobName}`;
+    const where = `${entry.label}:${jobName}`;
     const fromMatrix = matrixMajors(job, where);
     const fromSteps = stepMajors(job, where);
     allMatrixMajors.push(...fromMatrix);
     const majors = [...fromMatrix, ...fromSteps];
-    if (majors.length > 0) pins.push({ file, job: jobName, majors });
+    if (majors.length > 0) pins.push({ where, job: jobName, majors, shipped: entry.shipped });
   }
 }
 
@@ -283,14 +359,27 @@ if (allMatrixMajors.length < 2) {
   );
 }
 
-// --- 2. Every runtime CI exercises satisfies the published range.
-for (const { file, job, majors } of pins) {
+// --- 2. Every runtime a scanned workflow asks for satisfies the published range.
+//
+// The relation is the same for both scan roots; the CONSEQUENCE is not, so the
+// message is not. A local pin below the floor means this repository's own CI
+// vouches for a runtime the package disclaims. A shipped pin below the floor
+// means every adopter that scaffolds the template runs the published CLI below
+// its own engine floor - and npm reports that as EBADENGINE and keeps going, so
+// nothing in the adopter's CI turns red either.
+for (const { where, majors, shipped } of pins) {
   for (const major of majors) {
     if (major < floor) {
       failures.push(
-        `${file}:${job} runs on Node ${major}, below the engines.node floor of ${floor}. ` +
-          `CI would prove the package works on a runtime it does not claim to support, ` +
-          `or on one that tooling has already dropped.`,
+        shipped
+          ? `${where} scaffolds consumers onto Node ${major}, below the engines.node floor ` +
+            `of ${floor}. This file is copied into adopting repositories verbatim, so the ` +
+            `pin runs the published CLI under its own engine floor there. npm answers an ` +
+            `unmet engines range with EBADENGINE and continues, so the adopter's CI stays ` +
+            `green while running unsupported - the defect is invisible at both ends.`
+          : `${where} runs on Node ${major}, below the engines.node floor of ${floor}. ` +
+            `CI would prove the package works on a runtime it does not claim to support, ` +
+            `or on one that tooling has already dropped.`,
       );
     }
   }
@@ -318,8 +407,16 @@ if (floor < SUPPORTED_FLOOR) {
 // that publishes must be one some build or test job really ran. That fires
 // independently in both directions - a release pinned BELOW the tested set and a
 // release pinned ABOVE it are both untested release paths.
+// SHIPPED PINS ARE EXCLUDED HERE, and only here. Check 2 applies to every
+// pin the gate can see, because a runtime below the published floor is wrong
+// wherever it appears. Check 4 is different: it asks whether THIS
+// repository's release path runs on a runtime THIS repository's build path
+// proved. A job in assets/governance never runs here at all, so counting it
+// as a build job would let the shipped template vouch for a release runtime
+// nothing ever executed - the template would widen buildMajors and silence a
+// real finding. A gate scoped wider must not become a gate that asserts less.
 const majorsOf = (predicate) =>
-  new Set(pins.filter((p) => predicate(p.job)).flatMap((p) => p.majors));
+  new Set(pins.filter((p) => !p.shipped && predicate(p.job)).flatMap((p) => p.majors));
 
 const buildMajors = majorsOf((j) => !RELEASE_JOB.test(j));
 const releaseMajors = majorsOf((j) => RELEASE_JOB.test(j));
@@ -349,7 +446,7 @@ if (failures.length > 0) {
 }
 
 const summary = pins
-  .map(({ file, job, majors }) => `${file}:${job} -> ${[...new Set(majors)].sort((a, b) => a - b).join(", ")}`)
+  .map(({ where, majors }) => `${where} -> ${[...new Set(majors)].sort((a, b) => a - b).join(", ")}`)
   .join("\n    ");
 console.log(
   `Runtime support OK: engines.node >=${floor} (supported floor ${SUPPORTED_FLOOR}), ` +

--- a/tests/runtime-support.bats
+++ b/tests/runtime-support.bats
@@ -56,12 +56,51 @@ jobs:
 EOF
 }
 
+# assets/governance is the SECOND scan root: the workflow template
+# `aahp init --gates` copies into a consumer repository. $1 is the Node major
+# it pins. A file here never runs in this repository, so these tests are the
+# only thing that exercises the shipped-template half of the gate.
+tpl_dir() {
+    printf '%s/assets/governance' "$TEST_TMPDIR"
+}
+
+write_template() {
+    mkdir -p "$(tpl_dir)"
+    cat > "$(tpl_dir)/aahp-govern.yml" <<EOF
+name: AAHP Govern
+on: [push]
+jobs:
+  govern:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '$1'
+EOF
+}
+
 # ─── The load-bearing assertion: the real repository ────────────────────────
 
 @test "this repository's own workflows satisfy the runtime relation" {
     run node "$GATE" "$AAHP_ROOT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Runtime support OK"* ]]
+}
+
+@test "the gate actually reads the shipped template, not just what runs here" {
+    # The scan root is OPTIONAL - a project that ships no template is not a
+    # finding - so nothing in the gate can prove the root is still wired up.
+    # This does, against the real tree: the summary names every file scanned,
+    # so renaming assets/governance, dropping it from SCAN_ROOTS, or filtering
+    # it out all turn this red. Without it the widened scope could silently
+    # revert to reading one directory, which is the exact defect it fixed.
+    #
+    # Measured 2026-08-23: assets/governance/aahp-govern.yml pinned Node 20
+    # against engines.node '>=22' and this gate was green on every commit,
+    # because it scanned .github/workflows only.
+    run node "$GATE" "$AAHP_ROOT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"assets/governance/aahp-govern.yml:govern"* ]]
 }
 
 @test "the baseline fixture passes, so every mutation below starts from green" {
@@ -82,6 +121,60 @@ EOF
     run node "$GATE" "$TEST_TMPDIR"
     [ "$status" -eq 1 ]
     [[ "$output" == *"below the engines.node floor of 22"* ]]
+}
+
+@test "a shipped-template pin below the published floor is a failure" {
+    # The defect this scan root exists for. Every LOCAL pin clears the floor
+    # here, so the only thing that can turn this red is the template - which
+    # this repository never executes and, before 2026-08-23, never read either.
+    write_pkg ">=22"
+    write_good_workflow
+    write_template 20
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"assets/governance/aahp-govern.yml:govern scaffolds consumers onto Node 20"* ]]
+    [[ "$output" == *"EBADENGINE"* ]]
+}
+
+@test "a shipped template on the floor keeps the fixture green" {
+    # The control for the test above: same fixture, compliant pin. Without it a
+    # red result there could just mean "any template at all breaks the gate".
+    write_pkg ">=22"
+    write_good_workflow
+    write_template 22
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+}
+
+@test "a shipped template does not vouch for an untested release runtime" {
+    # Widening a gate's scope must not make it assert LESS. The release check is
+    # a membership test against the runtimes this repository's build jobs prove;
+    # a template job counted as a build job would supply Node 26 to that set and
+    # silence the finding below. It runs in the adopter's CI, never in ours, so
+    # it proves nothing about our release path.
+    write_pkg ">=22"
+    write_good_workflow
+    sed -i "s/node-version: '24'/node-version: '26'/" "$(wf_dir)/ci.yml"
+    write_template 26
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release path runs on Node 26, which no build or test job exercises"* ]]
+}
+
+@test "a project that ships no template is not a finding" {
+    # The asymmetry between the two scan roots, asserted rather than assumed.
+    # A missing .github/workflows is exit 2; a missing assets/governance is a
+    # package with nothing to ship, which is the shape of every other fixture
+    # in this file and of every consumer project.
+    write_pkg ">=22"
+    write_good_workflow
+    [ ! -d "$(tpl_dir)" ]
+
+    run node "$GATE" "$TEST_TMPDIR"
+    [ "$status" -eq 0 ]
 }
 
 @test "widening the published range below what CI proves is a failure" {


### PR DESCRIPTION
## The defect

`assets/governance/aahp-govern.yml` - the workflow `aahp init --gates` scaffolds into a consumer repository - pinned `node-version: '20'` while `package.json` declares `engines.node: ">=22"`.

A repository that scaffolds it runs `npm ci --ignore-scripts` and then `npx --no-install aahp check .` on Node 20: the published CLI, beneath the CLI's own engine floor, on a runtime end-of-life since 2026-04-30.

It would be silent at both ends. npm answers an unmet `engines` range with an `EBADENGINE` **warning** and exits 0, so the adopter's gate stays green while running unsupported. `.github/workflows/aahp-verify.yml` - the file that reaches consumers by the *other* route, `propagate.sh` - has pinned `'22'` with a comment naming the reason since the floor moved. The scaffolded file was never brought along.

### Blast radius today: zero repositories

Measured 2026-08-23 via code search across `homeofe` and `elvatis`: the only `aahp-govern.yml` in either organization is this asset itself. No consumer has scaffolded it. That matches the independent survey in `elvatis/ideabase` (`docs/reports/2026-08-22-session-dev-pc.md:187`), which found the portable workflow adopted by **zero** repositories - `propagate.sh` copies only `aahp-verify.yml`.

So this is a **latent** defect, not a live one: it was waiting for the first `aahp init --gates` to hand a stranger a workflow that runs our CLI below our own floor. Worth stating plainly, because it changes the urgency and not the correctness.

## The half worth fixing

`scripts/check-runtime-support.mjs` exists to assert exactly this relation, and its own header names the file this package propagates as the reason it was written. It scanned `.github/workflows/` only.

**AAHP propagates by two routes.** `propagate.sh` copies `aahp-verify.yml`; `aahp init --gates` copies `aahp-govern.yml`. The gate covered the first and was green on every commit while the second violated it. Its two sibling gates over the same file class already scan both directories:

| gate | `.github/workflows` | `assets/governance` |
|---|---|---|
| `tests/assert-workflow-hardening.mjs` | yes | yes (`SCAN_ROOTS`) |
| `scripts/check-workflow-pinning.mjs` | yes | yes (`TEMPLATE_DIRS`) |
| `scripts/check-runtime-support.mjs` | yes | **no** -> yes |

Correcting only the literal would leave the gate blind and the next pin free to drift the same way.

## What changed

- The pin is `'22'`, with the reason inline.
- The runtime gate reads `assets/governance/` as a second scan root.
- A shipped pin reports what actually goes wrong *there* - an adopter running the published CLI below its engine floor, invisibly - rather than the local wording about this repository's own CI.
- Shipped pins are **excluded** from the release-vs-build membership check (check 4). A job that never executes here must not vouch for a release runtime nothing proved. Widening a gate's scope must not let it assert less.

### The one asymmetry, stated rather than hidden

The new root is **optional**, unlike its sibling in `assert-workflow-hardening.mjs` where a missing root is exit 2. This gate also runs against fixture roots that legitimately ship no template, and a package that ships nothing has nothing to get wrong.

That leaves a hole - renaming or dropping the root would be silent - and it is closed from the other side: the gate's summary names every file it scanned, and `tests/runtime-support.bats` asserts the real tree's shipped template appears in it. Coverage is proved by observation of the real tree, not assumed from a flag.

## Verification

- `tests/runtime-support.bats` **30/30** (21 pre-existing, 9 new)
- `tests/init-gates.bats` and `tests/workflow-hardening.bats` green - `init-gates` diffs the scaffolded file against the asset byte-for-byte and asserts no version, so it was never a covering test for this
- `npm run check` green across all 10 gates; `aahp check .` green

**Mutation proof, both directions:**

| mutation | result |
|---|---|
| narrow the gate back to one directory | tests 2 and 5 go red |
| drop the `!p.shipped` exclusion from check 4 | test 7 goes red |
| restore the pin to `'20'` | gate exits 1 naming the file - the identical tree exited **0** before this change |

Per repository policy the full Bats suite is left to hosted Linux CI rather than run on Windows.

## Recorded, not changed

The template still references `actions/checkout@v4` and `actions/setup-node@v4` by tag while this repository's own workflows pin action SHAs. That is a separate decision about what adopters should read, and `check-workflow-pinning.mjs` currently accepts it, so it is noted here rather than folded into a pin fix.

## Acceptance criteria

- [x] `assets/governance/aahp-govern.yml` pins the engine floor
- [x] CHANGELOG entry under `[Unreleased]`
- [x] Checked whether any test asserted the version (`init-gates.bats` does not; nothing else did)
- [x] The gate that should have caught it now covers the shipped template
- [x] Mutation-proved in both directions, not only in the passing direction
- [x] Blast radius measured rather than assumed
- [x] Handoff state moved with the code (Layer 2)
